### PR TITLE
feat: make openid scope optional

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ The SDK is organized around several main client classes:
 - **Location:** `src/OidcClient.ts`
 - **Purpose:** Handle OIDC flows (Authorization Code + PKCE)
 - **Methods:**
-  - `login()`: Initiate login via redirect or popup
+  - `login()`: Initiate login via redirect or popup (`includeOpenidScope: false` is supported to omit automatic `openid` scope appending)
   - `logout()`: Log user out with optional redirect
   - `handleRedirect()`: Process OAuth callback after redirect
 
@@ -480,6 +480,36 @@ await client.login({
 });
 ```
 
+### Pattern: OAuth Authorization Without ID Token
+
+Use `includeOpenidScope: false` when you need OAuth authorization without requesting an ID token. This works with both OIDC and RBA flows.
+
+```typescript
+// OIDC authentication with ID token (default)
+await client.login({
+  popup: true
+  // includeOpenidScope defaults to true
+});
+
+// OIDC authorization without ID token
+await client.login(
+  { popup: true },
+  {
+    includeOpenidScope: false,
+    scope: "api:read"
+  }
+);
+
+// RBA authorization without ID token
+await client.rba.requestChallenge(
+  { userId: "user@example.com" },
+  {
+    includeOpenidScope: false,
+    scope: "api:read"
+  }
+);
+```
+
 ### Pattern: Transaction Details for RBA
 
 Pass contextual information for risk assessment:
@@ -786,4 +816,4 @@ Despite `package.json` specifying `"engines": { "bun": ">= 1", "node": ">= 22" }
 
 ---
 
-_Last updated: November 7, 2025 (streamlined for clarity and removed unnecessary details)_
+_Last updated: May 28, 2026 (updated OIDC includeOpenidScope behavior and examples)_

--- a/docs/api/IdaasClient/interfaces/ValidatedTokenResponse.md
+++ b/docs/api/IdaasClient/interfaces/ValidatedTokenResponse.md
@@ -10,15 +10,15 @@ A validated token response, contains the TokenResponse as well as the decoded an
 
 ## Properties
 
-### decodedIdToken
+### decodedIdToken?
 
-> **decodedIdToken**: `JWTPayload`
+> `optional` **decodedIdToken?**: `JWTPayload`
 
 ---
 
-### encodedIdToken
+### encodedIdToken?
 
-> **encodedIdToken**: `string`
+> `optional` **encodedIdToken?**: `string`
 
 ---
 

--- a/docs/api/index/interfaces/TokenOptions.md
+++ b/docs/api/index/interfaces/TokenOptions.md
@@ -28,6 +28,23 @@ Per OIDC spec, this parameter is optional and will be omitted from the authoriza
 
 ---
 
+### includeOpenidScope?
+
+> `optional` **includeOpenidScope?**: `boolean`
+
+Controls whether the `openid` scope is automatically added to the authorization request.
+
+When `true` (default), the `openid` scope is added and the flow expects an ID token. When `false`, the SDK omits
+automatic `openid` appending and does not require an ID token.
+
+#### Default
+
+```ts
+true;
+```
+
+---
+
 ### maxAge?
 
 > `optional` **maxAge?**: `number`
@@ -45,7 +62,7 @@ The scope to be used on this authentication request.
 
 This defaults to the `globalScope` in your `IdaasClientOptions` if not set. If you are setting extra scopes and require `profile` and `email` to be included then you must include them in the provided scope.
 
-Note: The `openid` scope is always applied regardless of this setting.
+Note: By default, the `openid` scope is automatically included so you receive an ID token. Only set `includeOpenidScope` to `false` if you want to omit the `openid` scope and perform OAuth authorization without an ID token.
 
 ---
 

--- a/docs/guides/oidc.md
+++ b/docs/guides/oidc.md
@@ -37,6 +37,25 @@ See the [OidcLoginOptions reference](../api/README.md#oidcloginoptions) for comp
 
 See the [TokenOptions reference](../api/README.md#tokenoptions) for complete details on all available options and their defaults.
 
+### Omitting `openid` with `includeOpenidScope: false`
+
+`oidc.login()` supports `includeOpenidScope: false`. When set, the SDK does not automatically append `openid` to the requested scope.
+
+- The flow can be OAuth-only, and no ID token is required.
+- Use this for access-token-only or step-up scenarios where existing sign-in state is already established.
+
+Use this when you only need an access token and do not want to request an ID token.
+
+```typescript
+await idaas.oidc.login(
+  { popup: true },
+  {
+    includeOpenidScope: false,
+    scope: "api:read"
+  }
+);
+```
+
 ### Popup (recommended for SPAs)
 
 ```typescript

--- a/docs/guides/rba.md
+++ b/docs/guides/rba.md
@@ -69,6 +69,22 @@ See the [AuthenticationRequestParams reference](../api/README.md#authenticationr
 
 See the [TokenOptions reference](../api/README.md#tokenoptions) for complete details on all available options and their defaults.
 
+#### OAuth without an ID token
+
+Use RBA token options with `includeOpenidScope: false` when you need OAuth authorization without requesting an ID token.
+
+```typescript
+await idaas.rba.requestChallenge(
+  {
+    userId: "user@example.com"
+  },
+  {
+    includeOpenidScope: false,
+    scope: "api:read"
+  }
+);
+```
+
 ## Rendering the challenge
 
 Use the response payload to decide what UI to show. For example, if `challenge.method === "OTP"` display an input for the code; if it’s `"PASSKEY"` trigger a WebAuthn ceremony.

--- a/src/AuthenticationTransaction.ts
+++ b/src/AuthenticationTransaction.ts
@@ -325,8 +325,10 @@ export class AuthenticationTransaction {
       requestBody,
     );
 
-    if (!(id_token && access_token)) {
-      throw new Error("failed to fetch id token and access token from IDaaS");
+    // If includeOpenidScope is false, do not require id_token
+    const requireIdToken = this.#tokenOptions.includeOpenidScope !== false;
+    if ((requireIdToken && !(id_token && access_token)) || (!requireIdToken && !access_token)) {
+      throw new Error("failed to fetch required tokens from IDaaS");
     }
 
     if (this.#tokenOptions.useRefreshToken && !refresh_token) {
@@ -335,7 +337,7 @@ export class AuthenticationTransaction {
 
     this.#authenticationDetails = {
       ...this.#authenticationDetails,
-      idToken: id_token as string,
+      idToken: id_token as string | undefined,
       accessToken: access_token as string,
       refreshToken: refresh_token as string,
       expiresAt: calculateEpochExpiry(expires_in),
@@ -457,6 +459,10 @@ export class AuthenticationTransaction {
 
   public getAuthenticationDetails = (): AuthenticationDetails => {
     return this.#authenticationDetails;
+  };
+
+  public requiresIdToken = (): boolean => {
+    return this.#tokenOptions.includeOpenidScope !== false;
   };
 
   #constructUserChallengeParams = (): UserChallengeParameters => {

--- a/src/IdaasClient.ts
+++ b/src/IdaasClient.ts
@@ -15,8 +15,8 @@ import { parseStepUpChallenge } from "./utils/wwwAuthenticate";
  */
 export interface ValidatedTokenResponse {
   tokenResponse: TokenResponse;
-  decodedIdToken: JWTPayload;
-  encodedIdToken: string;
+  decodedIdToken?: JWTPayload;
+  encodedIdToken?: string;
 }
 /**
  * The main client class for interacting with IDaaS authentication services.
@@ -48,6 +48,7 @@ export class IdaasClient {
       useRefreshToken: tokenOptions.useRefreshToken ?? false,
       maxAge: tokenOptions.maxAge,
       acrValues: tokenOptions.acrValues ?? "",
+      includeOpenidScope: tokenOptions.includeOpenidScope ?? true,
     };
 
     this.#context = new IdaasContext({

--- a/src/OidcClient.ts
+++ b/src/OidcClient.ts
@@ -118,6 +118,10 @@ export class OidcClient {
       throw new Error("Failed to recover IDaaS client state from local storage");
     }
     const { codeVerifier, redirectUri, state, nonce } = clientParams;
+    const tokenParams = this.#storageManager.getTokenParams();
+    if (!tokenParams) {
+      throw new Error("No token params stored, unable to parse");
+    }
 
     const authorizeCode = this.#validateAuthorizeResponse(authorizeResponse, state);
 
@@ -126,8 +130,9 @@ export class OidcClient {
       codeVerifier,
       redirectUri,
       nonce,
+      tokenParams.requireIdToken ?? true,
     );
-    this.#parseAndSaveTokenResponse(validatedTokenResponse);
+    this.#parseAndSaveTokenResponse(validatedTokenResponse, tokenParams);
     return null;
   }
 
@@ -199,7 +204,13 @@ export class OidcClient {
     return code;
   }
 
-  async #requestAndValidateTokens(code: string, codeVerifier: string, redirectUri: string, nonce: string) {
+  async #requestAndValidateTokens(
+    code: string,
+    codeVerifier: string,
+    redirectUri: string,
+    nonce: string,
+    requireIdToken: boolean,
+  ) {
     const { token_endpoint, id_token_signing_alg_values_supported, acr_values_supported } =
       await this.#context.getConfig();
 
@@ -212,6 +223,10 @@ export class OidcClient {
     };
 
     const tokenResponse = await requestToken(token_endpoint, tokenRequest);
+
+    if (!tokenResponse.id_token && !requireIdToken) {
+      return { tokenResponse };
+    }
 
     const { decodedJwt: decodedIdToken, idToken } = validateIdToken({
       clientId: this.#context.clientId,
@@ -244,16 +259,11 @@ export class OidcClient {
    * Extracts access token, ID token, and refresh token (if available).
    * @param validatedTokenResponse The validated response from the token endpoint
    */
-  #parseAndSaveTokenResponse(validatedTokenResponse: ValidatedTokenResponse): void {
+  #parseAndSaveTokenResponse(validatedTokenResponse: ValidatedTokenResponse, tokenParams: TokenParams): void {
     const { tokenResponse, decodedIdToken, encodedIdToken } = validatedTokenResponse;
     const { refresh_token, access_token, expires_in } = tokenResponse;
     const authTime = readAccessToken(access_token)?.auth_time;
     const expiresAt = calculateEpochExpiry(expires_in, authTime);
-    const tokenParams = this.#storageManager.getTokenParams();
-
-    if (!tokenParams) {
-      throw new Error("No token params stored, unable to parse");
-    }
 
     const { audience, scope, maxAge } = tokenParams;
     const maxAgeExpiry = maxAge ? calculateEpochExpiry(maxAge.toString(), authTime) : undefined;
@@ -273,10 +283,13 @@ export class OidcClient {
       acr,
     };
 
-    this.#storageManager.saveIdToken({
-      encoded: encodedIdToken,
-      decoded: decodedIdToken,
-    });
+    if (encodedIdToken && decodedIdToken) {
+      this.#storageManager.saveIdToken({
+        encoded: encodedIdToken,
+        decoded: decodedIdToken,
+      });
+    }
+
     this.#storageManager.saveAccessToken(newAccessToken);
   }
 
@@ -303,6 +316,7 @@ export class OidcClient {
     const tokenParams: TokenParams = {
       audience: tokenOptions.audience ?? this.#context.tokenOptions.audience,
       scope: usedScope,
+      requireIdToken: (tokenOptions.includeOpenidScope ?? this.#context.tokenOptions.includeOpenidScope) !== false,
     };
 
     if (tokenOptions.maxAge !== undefined && tokenOptions.maxAge >= 0) {
@@ -319,9 +333,10 @@ export class OidcClient {
       codeVerifier,
       finalRedirectUri,
       nonce,
+      tokenParams.requireIdToken ?? true,
     );
 
-    this.#parseAndSaveTokenResponse(validatedTokenResponse);
+    this.#parseAndSaveTokenResponse(validatedTokenResponse, tokenParams);
 
     // redirect only if the redirectUri is not the current uri
     if (formatUrl(window.location.href) !== formatUrl(finalRedirectUri)) {
@@ -354,6 +369,7 @@ export class OidcClient {
     const tokenParams: TokenParams = {
       audience: tokenOptions.audience ?? this.#context.tokenOptions.audience,
       scope: usedScope,
+      requireIdToken: (tokenOptions.includeOpenidScope ?? this.#context.tokenOptions.includeOpenidScope) !== false,
     };
 
     if (tokenOptions.maxAge !== undefined && tokenOptions.maxAge >= 0) {

--- a/src/RbaClient.ts
+++ b/src/RbaClient.ts
@@ -200,15 +200,25 @@ export class RbaClient {
   ) => {
     const oidcConfig = await this.#context.getConfig();
 
+    // Scope normalization: preserve caller/context scope as-is and only provide a fallback when none exists.
+    // includeOpenidScope controls automatic `openid` appending in URL generation and should not remove explicit scope values.
+    let normalizedScope = tokenOptions?.scope ?? this.#context.tokenOptions.scope;
+    const effectiveincludeOpenidScope =
+      tokenOptions?.includeOpenidScope ?? this.#context.tokenOptions.includeOpenidScope;
+    if (effectiveincludeOpenidScope === false && !tokenOptions?.scope && !this.#context.tokenOptions.scope) {
+      normalizedScope = "profile email";
+    }
+
     this.#authenticationTransaction = new AuthenticationTransaction({
       oidcConfig,
       authenticationRequestParams,
       tokenOptions: {
         audience: tokenOptions?.audience ?? this.#context.tokenOptions.audience,
-        scope: tokenOptions?.scope ?? this.#context.tokenOptions.scope,
+        scope: normalizedScope,
         acrValues: tokenOptions?.acrValues ?? this.#context.tokenOptions.acrValues,
         useRefreshToken: tokenOptions?.useRefreshToken ?? this.#context.tokenOptions.useRefreshToken,
         maxAge: tokenOptions?.maxAge ?? this.#context.tokenOptions.maxAge,
+        includeOpenidScope: effectiveincludeOpenidScope,
       },
       clientId: this.#context.clientId,
     });
@@ -222,16 +232,13 @@ export class RbaClient {
     const { idToken, accessToken, refreshToken, scope, expiresAt, maxAge, audience, acr } =
       this.#authenticationTransaction.getAuthenticationDetails();
 
-    // Require the access token, id token, and necessary claims
-    if (!(idToken && accessToken && expiresAt && scope)) {
+    // Only require accessToken for OAuth-only flows
+    const requireIdToken = this.#authenticationTransaction.requiresIdToken();
+    if (!accessToken || !expiresAt || !scope || (requireIdToken && !idToken)) {
       throw new Error("Error retrieving tokens from transaction");
     }
 
-    // Saving tokens
-    this.#storageManager.saveIdToken({
-      encoded: idToken,
-      decoded: decodeJwt(idToken),
-    });
+    // Save access token always
     this.#storageManager.saveAccessToken({
       accessToken,
       expiresAt,
@@ -241,6 +248,14 @@ export class RbaClient {
       maxAgeExpiry: maxAge ? calculateEpochExpiry(maxAge.toString()) : undefined,
       acr,
     });
+
+    // Save ID token only if present
+    if (idToken) {
+      this.#storageManager.saveIdToken({
+        encoded: idToken,
+        decoded: decodeJwt(idToken),
+      });
+    }
 
     this.#authenticationTransaction = undefined;
   };

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -60,7 +60,7 @@ export interface TokenOptions {
    *
    * This defaults to the `globalScope` in your `IdaasClientOptions` if not set. If you are setting extra scopes and require `profile` and `email` to be included then you must include them in the provided scope.
    *
-   * Note: The `openid` scope is always applied regardless of this setting.
+   * Note: By default, the `openid` scope is automatically included so you receive an ID token. Only set `includeOpenidScope` to `false` if you want to omit the `openid` scope and perform OAuth authorization without an ID token.
    */
   scope?: string;
 
@@ -82,6 +82,16 @@ export interface TokenOptions {
    * Example: `"knowledge possession"`
    */
   acrValues?: string;
+
+  /**
+   * Controls whether the `openid` scope is automatically added to the authorization request.
+   *
+   * When `true` (default), the `openid` scope is added and the flow expects an ID token. When `false`, the SDK omits
+   * automatic `openid` appending and does not require an ID token.
+   *
+   * @default true
+   */
+  includeOpenidScope?: boolean;
 }
 
 /**

--- a/src/storage/StorageManager.ts
+++ b/src/storage/StorageManager.ts
@@ -25,6 +25,7 @@ export interface ClientParams {
 export interface TokenParams {
   audience?: string;
   scope: string;
+  requireIdToken?: boolean;
 
   // RFC 9470
   maxAge?: number;

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -44,7 +44,11 @@ export const generateAuthorizationUrl = async (
 
   // Process scope (default to empty string if not provided)
   const scopeAsArray = options.tokenOptions.scope ? options.tokenOptions.scope.split(" ").filter(Boolean) : [];
-  scopeAsArray.push("openid");
+
+  // Add openid scope if requested (for OIDC authentication to receive ID token)
+  if (options.tokenOptions.includeOpenidScope !== false) {
+    scopeAsArray.push("openid");
+  }
 
   if (options.tokenOptions.useRefreshToken) {
     scopeAsArray.push("offline_access");

--- a/test/unit/IdaasClient/handleRedirect.test.ts
+++ b/test/unit/IdaasClient/handleRedirect.test.ts
@@ -2,6 +2,7 @@ import { afterAll, afterEach, beforeEach, describe, expect, jest, spyOn, test } 
 import * as jwt from "../../../src/utils/jwt";
 import {
   NO_DEFAULT_IDAAS_CLIENT,
+  TEST_ACCESS_TOKEN,
   TEST_ACCESS_TOKEN_KEY,
   TEST_ACR_CLAIM,
   TEST_BASE_URI,
@@ -11,6 +12,7 @@ import {
   TEST_ID_TOKEN_OBJECT,
   TEST_SCOPE,
   TEST_STATE,
+  TEST_TOKEN_PAIR,
   TEST_TOKEN_PARAMS,
 } from "../constants";
 import { mockFetch, storeData } from "../helpers";
@@ -30,7 +32,7 @@ describe("IdaasClient.handleRedirect", () => {
     };
   });
   // Mock JWT validation to avoid complex crypto operations in tests
-  spyOn(jwt, "validateIdToken").mockImplementation(() => {
+  const spyOnValidateIdToken = spyOn(jwt, "validateIdToken").mockImplementation(() => {
     return { decodedJwt: TEST_ID_TOKEN_OBJECT.decoded, idToken: TEST_ID_TOKEN_OBJECT.encoded };
   });
   const loginSuccessUrl = `${TEST_BASE_URI}?code=${TEST_CODE}&state=${TEST_STATE}`;
@@ -161,6 +163,38 @@ describe("IdaasClient.handleRedirect", () => {
       expect(storedToken).toBeDefined();
       expect(storedToken?.decoded).toBeDefined();
       expect(storedToken?.encoded).toBeDefined();
+    });
+
+    test("preserves existing ID token when openid scope is omitted", async () => {
+      const tokenResponseWithoutIdToken = {
+        access_token: TEST_ACCESS_TOKEN,
+        expires_in: "300",
+        token_type: "Bearer",
+      };
+
+      localStorage.setItem(
+        TEST_TOKEN_PAIR.key,
+        JSON.stringify({ ...TEST_TOKEN_PARAMS, scope: "profile email", requireIdToken: false }),
+      );
+      storeData({ clientParams: true, idToken: true });
+      window.location.href = loginSuccessUrl;
+
+      // @ts-expect-error not full type
+      spyOn(window, "fetch").mockImplementation((url: string) => {
+        if (url === `${TEST_BASE_URI}/token`) {
+          return Promise.resolve({
+            json: () => Promise.resolve(tokenResponseWithoutIdToken),
+          } as Response);
+        }
+
+        return mockFetch(url);
+      });
+
+      await NO_DEFAULT_IDAAS_CLIENT.oidc.handleRedirect();
+
+      expect(spyOnValidateIdToken).not.toHaveBeenCalled();
+      expect(localStorage.getItem(TEST_ID_TOKEN_KEY)).not.toBeNull();
+      expect(localStorage.getItem(TEST_ACCESS_TOKEN_KEY)).not.toBeNull();
     });
   });
 });

--- a/test/unit/IdaasClient/login.test.ts
+++ b/test/unit/IdaasClient/login.test.ts
@@ -137,6 +137,18 @@ describe("IdaasClient.oidc.login", () => {
         expect(scopeArr).toContain("test_scope2");
       });
 
+      test("openid scope is omitted when includeOpenidScope is false", async () => {
+        await NO_DEFAULT_IDAAS_CLIENT.oidc.login({}, { scope: "profile email", includeOpenidScope: false });
+
+        const { url: authUrl } = (await spyOnGenerateAuthorizationUrl.mock.results[0]?.value) as { url: string };
+        const { scope } = getUrlParams(authUrl);
+        const scopeArr = scope.split(" ");
+
+        expect(scopeArr).toContain("profile");
+        expect(scopeArr).toContain("email");
+        expect(scopeArr).not.toContain("openid");
+      });
+
       test("default scope used if none supplied in client constructor or login call", async () => {
         await NO_DEFAULT_IDAAS_CLIENT.oidc.login();
 

--- a/test/unit/IdaasClient/requestChallenge.test.ts
+++ b/test/unit/IdaasClient/requestChallenge.test.ts
@@ -1,0 +1,123 @@
+import { afterAll, afterEach, describe, expect, jest, spyOn, test } from "bun:test";
+import * as api from "../../../src/api";
+import { IdaasClient } from "../../../src/IdaasClient";
+import * as urlUtils from "../../../src/utils/url";
+import { TEST_CLIENT_ID, TEST_ISSUER_URI, TEST_OIDC_CONFIG } from "../constants";
+
+describe("IdaasClient.rba.requestChallenge", () => {
+  // @ts-expect-error non full type
+  const spyOnFetch = spyOn(window, "fetch").mockImplementation(async (url: string) => {
+    if (url === `${TEST_ISSUER_URI}/.well-known/openid-configuration`) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(TEST_OIDC_CONFIG),
+      } as Response);
+    }
+
+    throw new Error(`Unexpected fetch call in test: ${url}`);
+  });
+
+  const spyOnGetAuthRequestId = spyOn(api, "getAuthRequestId").mockResolvedValue({
+    authRequestKey: "test-auth-request-key",
+    applicationId: "test-application-id",
+  });
+
+  const spyOnRequestAuthChallenge = spyOn(api, "requestAuthChallenge").mockResolvedValue({
+    token: "test-token",
+  } as never);
+
+  const spyOnGenerateAuthorizationUrl = spyOn(urlUtils, "generateAuthorizationUrl").mockResolvedValue({
+    url: `${TEST_ISSUER_URI}/authorizejwt?scope=profile%20email`,
+    nonce: "test-nonce",
+    state: "test-state",
+    codeVerifier: "test-code-verifier",
+    usedScope: "profile email",
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  test("propagates includeOpenidScope=false in RBA token options", async () => {
+    const client = new IdaasClient(
+      {
+        issuerUrl: TEST_ISSUER_URI,
+        clientId: TEST_CLIENT_ID,
+        storageType: "localstorage",
+      },
+      {
+        scope: "openid profile email",
+      },
+    );
+
+    await client.rba.requestChallenge(
+      {
+        userId: "user@example.com",
+        strict: true,
+        preferredAuthenticationMethod: "PASSWORD",
+      },
+      {
+        scope: "profile email",
+        includeOpenidScope: false,
+      },
+    );
+
+    expect(spyOnGetAuthRequestId).toHaveBeenCalledTimes(1);
+    expect(spyOnRequestAuthChallenge).toHaveBeenCalledTimes(1);
+    expect(spyOnFetch).toHaveBeenCalledTimes(1);
+
+    expect(spyOnGenerateAuthorizationUrl).toHaveBeenCalledTimes(1);
+    expect(spyOnGenerateAuthorizationUrl).toHaveBeenCalledWith(
+      TEST_OIDC_CONFIG,
+      expect.objectContaining({
+        type: "jwt",
+        clientId: TEST_CLIENT_ID,
+        tokenOptions: expect.objectContaining({
+          scope: "profile email",
+          includeOpenidScope: false,
+        }),
+      }),
+    );
+  });
+
+  test("preserves default scope when includeOpenidScope=false", async () => {
+    const client = new IdaasClient(
+      {
+        issuerUrl: TEST_ISSUER_URI,
+        clientId: TEST_CLIENT_ID,
+        storageType: "localstorage",
+      },
+      {
+        scope: "openid profile email",
+      },
+    );
+
+    await client.rba.requestChallenge(
+      {
+        userId: "user@example.com",
+        strict: true,
+        preferredAuthenticationMethod: "PASSWORD",
+      },
+      {
+        includeOpenidScope: false,
+      },
+    );
+
+    expect(spyOnGenerateAuthorizationUrl).toHaveBeenCalledWith(
+      TEST_OIDC_CONFIG,
+      expect.objectContaining({
+        type: "jwt",
+        clientId: TEST_CLIENT_ID,
+        tokenOptions: expect.objectContaining({
+          scope: "openid profile email",
+          includeOpenidScope: false,
+        }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
This feature adds support for OAuth-only RBA challenge flows by allowing the openid scope to be disabled when requested. When includeOpenIdScope is set to false, the SDK no longer appends openid to the authorization request and will accept token responses without an ID token.

~~-OIDC login still requires openid and will throw if includeOpenIdScope is set to false.~~
-If openid is disabled and no explicit scope is provided, the SDK falls back to a safe non-OIDC scope set ("profile email").
