### PR TITLE
feat: add JWT signature validation and update related tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ import { IdaasClient } from "@entrustcorp/idaas-auth-js";
 const idaas = new IdaasClient({
   issuerUrl: "https://example.us.trustedauth.com/api/oidc",
   clientId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-  storageType: "localstorage"
+  storageType: "localstorage", // Optional, defaults to "memory"
+  // Optional: restrict ID token signature algorithms accepted during OIDC validation
+  allowedIdTokenSigningAlgorithms: ["RS256"]
 });
 
 // Popup flow (auto stores tokens)
@@ -70,6 +72,8 @@ await idaas.oidc.login({ popup: true });
 // Use tokens
 const accessToken = await idaas.getAccessToken();
 ```
+
+When `allowedIdTokenSigningAlgorithms` is provided, OIDC login/token exchange validates the ID token signature algorithm against this allowlist and rejects tokens signed with algorithms outside the list. The configured value must match the ID token signing algorithm(s) defined in your IDaaS SPA application settings.
 
 See the [Quickstart guide](docs/quickstart.md) for configuration options, redirect flows, error handling, and self-hosted examples.
 

--- a/docs/api/index/interfaces/IdaasClientOptions.md
+++ b/docs/api/index/interfaces/IdaasClientOptions.md
@@ -10,6 +10,18 @@ The configurable options of the IdaasClient.
 
 ## Properties
 
+### allowedIdTokenSigningAlgorithms?
+
+> `optional` **allowedIdTokenSigningAlgorithms?**: `string`[]
+
+The allowed algorithms for validating ID token signatures.
+
+Defaults to: `PS256 PS384 PS512 RS256 RS384 RS512 EC256 ES384 ES512`.
+
+Provide this to restrict validation to a specific subset.
+
+---
+
 ### clientId
 
 > **clientId**: `string`

--- a/docs/guides/oidc.md
+++ b/docs/guides/oidc.md
@@ -17,7 +17,8 @@ const idaas = new IdaasClient(
   {
     issuerUrl: "https://example.trustedauth.com",
     clientId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-    storageType: "localstorage"
+    storageType: "localstorage",
+    allowedIdTokenSigningAlgorithms: ["RS256"]
   },
   {
     scope: "openid profile email",
@@ -26,6 +27,22 @@ const idaas = new IdaasClient(
   }
 );
 ```
+
+### Restrict ID token signing algorithms
+
+Use `allowedIdTokenSigningAlgorithms` in `IdaasClient` options to control which ID token signature algorithms are accepted during OIDC validation.
+
+```typescript
+const idaas = new IdaasClient({
+  issuerUrl: "https://example.trustedauth.com",
+  clientId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  allowedIdTokenSigningAlgorithms: ["RS256", "PS256"]
+});
+```
+
+If the ID token returned by the OIDC flow uses an algorithm not in this list, login fails and throws an error.
+
+Set this list to match the ID token signing algorithm(s) configured for your IDaaS SPA application. If they do not match, OIDC login will fail during token validation.
 
 ## Login
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -26,7 +26,9 @@ const idaas = new IdaasClient(
   {
     issuerUrl: "https://example.trustedauth.com", // OIDC issuer from your tenant
     clientId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890", // Your application's client ID
-    storageType: "localstorage" // "memory" | "localstorage"
+    storageType: "localstorage", // Optional, defaults to "memory". Use "localstorage" to persist tokens across reloads.
+    // Optional: restrict accepted ID token signing algorithms for OIDC validation
+    allowedIdTokenSigningAlgorithms: ["RS256"]
   },
   {
     scope: "openid profile email", // defaults provided; override as needed
@@ -35,6 +37,9 @@ const idaas = new IdaasClient(
   }
 );
 ```
+
+If `allowedIdTokenSigningAlgorithms` is set, OIDC login only succeeds when the returned ID token is signed with one of the allowed algorithms.
+The configured value must match the ID token signing algorithm(s) defined in your IDaaS SPA application settings.
 
 The client exposes three facades:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -15,11 +15,12 @@ This guide lists common issues encountered when integrating the IDaaS Auth JS SD
 
 ## Hosted OIDC flows (`oidc`)
 
-| Symptom                                    | Likely cause                                                                         | Fix                                                                                              |
-| ------------------------------------------ | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
-| Popup window blocked or immediately closed | Browser blocked popups.                                                              | Switch to redirect flow (`popup: false`) or ask users to allow popups for your domain.           |
-| `invalid_redirect_uri` error               | Redirect URI sent by SDK isn’t registered.                                           | Update the tenant app configuration or pass the correct `redirectUri` to `login`.                |
-| `state mismatch`/`invalid_state`           | Callback handled without original state (e.g., multiple clients or double handling). | Use a single `IdaasClient` instance per request and call `handleRedirect()` only once per login. |
+| Symptom                                    | Likely cause                                                                            | Fix                                                                                                                                                                      |
+| ------------------------------------------ | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Popup window blocked or immediately closed | Browser blocked popups.                                                                 | Switch to redirect flow (`popup: false`) or ask users to allow popups for your domain.                                                                                   |
+| `invalid_redirect_uri` error               | Redirect URI sent by SDK isn’t registered.                                              | Update the tenant app configuration or pass the correct `redirectUri` to `login`.                                                                                        |
+| `state mismatch`/`invalid_state`           | Callback handled without original state (e.g., multiple clients or double handling).    | Use a single `IdaasClient` instance per request and call `handleRedirect()` only once per login.                                                                         |
+| OIDC login fails during token validation   | ID token was signed with an algorithm not allowed by `allowedIdTokenSigningAlgorithms`. | Ensure `allowedIdTokenSigningAlgorithms` matches the ID token signing algorithm(s) configured in your IDaaS SPA application. Or remove the override to use SDK defaults. |
 
 ---
 

--- a/src/IdaasClient.ts
+++ b/src/IdaasClient.ts
@@ -38,7 +38,10 @@ export class IdaasClient {
    * @param options Configuration options for the client including issuer URL, client ID, and storage type
    * @param tokenOptions Default token options including audience, scope, and refresh token settings
    */
-  constructor({ issuerUrl, clientId, storageType = "memory" }: IdaasClientOptions, tokenOptions: TokenOptions = {}) {
+  constructor(
+    { issuerUrl, clientId, storageType = "memory", allowedIdTokenSigningAlgorithms }: IdaasClientOptions,
+    tokenOptions: TokenOptions = {},
+  ) {
     this.#storageManager = new StorageManager(clientId, storageType);
 
     // Normalize token options with defaults (audience remains optional per OIDC spec)
@@ -55,6 +58,7 @@ export class IdaasClient {
       issuerUrl,
       clientId,
       tokenOptions: normalizedTokenOptions,
+      allowedIdTokenSigningAlgorithms,
     });
 
     // Initialize clients with this.#context instance as the context provider

--- a/src/IdaasContext.ts
+++ b/src/IdaasContext.ts
@@ -16,6 +16,7 @@ export class IdaasContext {
   readonly #issuerUrl: string;
   readonly #clientId: string;
   readonly #tokenOptions: NormalizedTokenOptions;
+  readonly #allowedIdTokenSigningAlgorithms?: string[];
 
   #config?: OidcConfig;
 
@@ -23,12 +24,15 @@ export class IdaasContext {
     issuerUrl,
     clientId,
     tokenOptions,
+    allowedIdTokenSigningAlgorithms,
   }: {
     issuerUrl: string;
     clientId: string;
     tokenOptions: NormalizedTokenOptions;
+    allowedIdTokenSigningAlgorithms?: string[];
   }) {
     this.#tokenOptions = tokenOptions;
+    this.#allowedIdTokenSigningAlgorithms = allowedIdTokenSigningAlgorithms;
     this.#issuerUrl = issuerUrl;
     this.#clientId = clientId;
   }
@@ -43,6 +47,10 @@ export class IdaasContext {
 
   get tokenOptions() {
     return this.#tokenOptions;
+  }
+
+  get allowedIdTokenSigningAlgorithms() {
+    return this.#allowedIdTokenSigningAlgorithms;
   }
 
   /**

--- a/src/OidcClient.ts
+++ b/src/OidcClient.ts
@@ -211,7 +211,7 @@ export class OidcClient {
     nonce: string,
     requireIdToken: boolean,
   ) {
-    const { token_endpoint, id_token_signing_alg_values_supported, acr_values_supported } =
+    const { token_endpoint, id_token_signing_alg_values_supported, acr_values_supported, jwks_uri } =
       await this.#context.getConfig();
 
     const tokenRequest: AccessTokenRequest = {
@@ -228,13 +228,15 @@ export class OidcClient {
       return { tokenResponse };
     }
 
-    const { decodedJwt: decodedIdToken, idToken } = validateIdToken({
+    const { decodedJwt: decodedIdToken, idToken } = await validateIdToken({
       clientId: this.#context.clientId,
       idToken: tokenResponse.id_token,
       issuer: this.#context.issuerUrl,
       nonce,
       idTokenSigningAlgValuesSupported: id_token_signing_alg_values_supported,
+      allowedIdTokenSigningAlgorithms: this.#context.allowedIdTokenSigningAlgorithms,
       acrValuesSupported: acr_values_supported,
+      jwksEndpoint: jwks_uri,
     });
 
     return { tokenResponse, decodedIdToken, encodedIdToken: idToken };

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -28,6 +28,15 @@ export interface IdaasClientOptions {
    * @default "memory"
    */
   storageType?: "memory" | "localstorage";
+
+  /**
+   * The allowed algorithms for validating ID token signatures.
+   *
+   * Defaults to: `PS256 PS384 PS512 RS256 RS384 RS512 EC256 ES384 ES512`.
+   *
+   * Provide this to restrict validation to a specific subset.
+   */
+  allowedIdTokenSigningAlgorithms?: string[];
 }
 
 /**

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -1,13 +1,31 @@
 import { createRemoteJWKSet, decodeJwt, decodeProtectedHeader, type JWTPayload, jwtVerify } from "jose";
 import type { UserClaims } from "../models";
 
+export const DEFAULT_ALLOWED_ID_TOKEN_SIGNING_ALGORITHMS = [
+  "PS256",
+  "PS384",
+  "PS512",
+  "RS256",
+  "RS384",
+  "RS512",
+  "EC256",
+  "ES384",
+  "ES512",
+];
+
+const isAllowedIdTokenSigningAlgorithm = (value: string): boolean => {
+  return DEFAULT_ALLOWED_ID_TOKEN_SIGNING_ALGORITHMS.includes(value);
+};
+
 export interface ValidateIdTokenParams {
   idToken?: string | JWTPayload;
   issuer: string;
   clientId: string;
   nonce: string;
   idTokenSigningAlgValuesSupported: string[];
+  allowedIdTokenSigningAlgorithms?: string[];
   acrValuesSupported?: string[];
+  jwksEndpoint: string;
 }
 
 export interface ValidateUserInfoTokenParams {
@@ -32,17 +50,24 @@ export interface DecodedAccessToken {
 /**
  * Validate the signed ID token received from the /token endpoint in accordance with the OIDC specification.
  *
- * Note: Since this client only supports the Authorization Code flow, we are able to skip JWT signature validation
- * and instead rely on TLS, as described in 3.1.3.7 #6 of the OIDC core specification.
+ * Validates the token by checking:
+ * - Required claims (sub, iat, iss, aud, exp, nonce)
+ * - Claim values (issuer, audience/azp, nonce)
+ * - Token expiration (exp) and not-before (nbf) times with clock skew leeway
+ * - Algorithm is supported
+ * - JWT signature against the OpenID Provider's JWKS endpoint
+ *
  * See more at: https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation
  */
-export const validateIdToken = ({
+export const validateIdToken = async ({
   idToken,
   issuer,
   clientId,
   nonce,
   idTokenSigningAlgValuesSupported,
+  allowedIdTokenSigningAlgorithms,
   acrValuesSupported,
+  jwksEndpoint,
 }: ValidateIdTokenParams) => {
   if (!idToken) {
     throw new Error("No ID token supplied");
@@ -54,6 +79,7 @@ export const validateIdToken = ({
   let alg: string | undefined;
 
   try {
+    // eject if this happens, don't allow unsigned token
     if (typeof idToken !== "string") {
       // If the token is not a jwt string, use it directly as an unsigned object
       stringifiedToken = JSON.stringify(idToken);
@@ -75,6 +101,10 @@ export const validateIdToken = ({
 
   if (!decodedJwt.iat) {
     throw new Error("Issued At (iat) claim is missing from ID token");
+  }
+
+  if (typeof decodedJwt.iat !== "number" || !Number.isFinite(decodedJwt.iat)) {
+    throw new Error("Issued At (iat) claim must be a valid numeric timestamp");
   }
 
   if (!decodedJwt.iss) {
@@ -119,17 +149,6 @@ export const validateIdToken = ({
     }
   }
 
-  // Validate alg against default RS256
-  if (!alg) {
-    throw new Error("Algorithm (alg) claim is missing from ID token");
-  }
-
-  if (!idTokenSigningAlgValuesSupported.includes(alg)) {
-    throw new Error(
-      `Algorithm (alg) claim ${alg} in the ID token ${alg} is not one of the supported ${idTokenSigningAlgValuesSupported}`,
-    );
-  }
-
   // Default 15s leeway to account for clock skew issues with nbf and exp claims
   const leeway = 15;
 
@@ -139,6 +158,17 @@ export const validateIdToken = ({
 
   if (now > expDate) {
     throw new Error(`Expiration Time (exp) claim ${decodedJwt.exp} indicates that this token is now expired at ${now}`);
+  }
+
+  if (decodedJwt.iat > decodedJwt.exp) {
+    throw new Error(
+      `Issued At (iat) claim ${decodedJwt.iat} must not be later than Expiration Time (exp) claim ${decodedJwt.exp}`,
+    );
+  }
+
+  const iatDate = new Date((decodedJwt.iat - leeway) * 1000);
+  if (now < iatDate) {
+    throw new Error(`Issued At (iat) claim ${decodedJwt.iat} indicates that this token was issued in the future`);
   }
 
   if (decodedJwt.nbf) {
@@ -165,6 +195,57 @@ export const validateIdToken = ({
     throw new Error(
       `Authentication Context Class Reference (acr) claim ${acrClaim} is not one of the supported ${acrValuesSupported}`,
     );
+  }
+
+  if (!alg) {
+    throw new Error("Algorithm (alg) claim is missing from ID token");
+  }
+
+  if (allowedIdTokenSigningAlgorithms?.length === 0) {
+    throw new Error("Allowed ID token signing algorithms list cannot be empty when provided");
+  }
+
+  const requestedAllowedAlgorithms = allowedIdTokenSigningAlgorithms ?? DEFAULT_ALLOWED_ID_TOKEN_SIGNING_ALGORITHMS;
+  const invalidAlgorithms = requestedAllowedAlgorithms.filter(
+    (requestedAlg) => !isAllowedIdTokenSigningAlgorithm(requestedAlg),
+  );
+
+  if (invalidAlgorithms.length > 0) {
+    throw new Error(
+      `Allowed ID token signing algorithms contains unsupported values: ${invalidAlgorithms.join(", ")}. Supported values are ${DEFAULT_ALLOWED_ID_TOKEN_SIGNING_ALGORITHMS.join(", ")}`,
+    );
+  }
+
+  const effectiveAllowedAlgorithms = requestedAllowedAlgorithms.filter((requestedAlg) =>
+    idTokenSigningAlgValuesSupported.includes(requestedAlg),
+  );
+
+  if (effectiveAllowedAlgorithms.length === 0) {
+    throw new Error(
+      `No allowed ID token signing algorithms are supported by the OpenID Provider. Requested: ${requestedAllowedAlgorithms.join(", ")}; Provider supports: ${idTokenSigningAlgValuesSupported.join(", ")}`,
+    );
+  }
+
+  if (!effectiveAllowedAlgorithms.includes(alg)) {
+    throw new Error(
+      `Algorithm (alg) claim ${alg} in the ID token is not one of the allowed algorithms ${effectiveAllowedAlgorithms}`,
+    );
+  }
+
+  // Verify the JWT signature against the JWKS endpoint if the token is signed
+  if (typeof idToken === "string") {
+    const jwks = createRemoteJWKSet(new URL(jwksEndpoint));
+
+    try {
+      await jwtVerify(idToken, jwks, {
+        audience: clientId,
+        issuer,
+      });
+    } catch (error) {
+      throw new Error(
+        `ID token signature verification failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
   }
 
   return { idToken: stringifiedToken, decodedJwt };

--- a/test/e2e/login.spec.ts
+++ b/test/e2e/login.spec.ts
@@ -15,13 +15,38 @@ const CLIENT_PARAMS_KEY = `entrust.${CLIENT_ID}.clientParams`;
 const ACCESS_TOKENS_KEY = `entrust.${CLIENT_ID}.accessTokens`;
 const ID_TOKENS_KEY = `entrust.${CLIENT_ID}.idToken`;
 
+const getAppLocalStorage = async (page: Page) => {
+  const storage = await page.context().storageState();
+  const appOrigin = new URL(DEV_SERVER).origin;
+
+  // Browser implementations can return origins in different order.
+  const matchingOrigin =
+    storage.origins.find(({ origin }) => origin === appOrigin) ??
+    storage.origins.find(({ localStorage }) =>
+      localStorage.some(
+        ({ name }) => name === ACCESS_TOKENS_KEY || name === ID_TOKENS_KEY || name === CLIENT_PARAMS_KEY,
+      ),
+    );
+
+  return matchingOrigin?.localStorage ?? [];
+};
+
 /**
  * Helper function to validate tokens are correctly stored in localStorage
  */
 const validateTokenStorage = async (page: Page, expectedAccessToken: string, expectedIdToken: string) => {
-  const storage = await page.context().storageState();
-  const accessTokens = storage.origins[0]?.localStorage.find(({ name }) => name === ACCESS_TOKENS_KEY);
-  const idToken = storage.origins[0]?.localStorage.find(({ name }) => name === ID_TOKENS_KEY);
+  await expect
+    .poll(async () => {
+      const localStorageEntries = await getAppLocalStorage(page);
+      const hasAccessToken = localStorageEntries.some(({ name }) => name === ACCESS_TOKENS_KEY);
+      const hasIdToken = localStorageEntries.some(({ name }) => name === ID_TOKENS_KEY);
+      return hasAccessToken && hasIdToken;
+    })
+    .toBeTruthy();
+
+  const localStorageEntries = await getAppLocalStorage(page);
+  const accessTokens = localStorageEntries.find(({ name }) => name === ACCESS_TOKENS_KEY);
+  const idToken = localStorageEntries.find(({ name }) => name === ID_TOKENS_KEY);
 
   expect(accessTokens).toBeTruthy();
   if (accessTokens) {
@@ -112,10 +137,10 @@ test("login with redirect", async ({ page }) => {
 
   const url = new URL(page.url());
   const searchParams = url.searchParams;
-  const storage = await page.context().storageState();
+  const localStorageEntries = await getAppLocalStorage(page);
 
   // Client state in local storage should match the returning url state
-  const clientParams = storage.origins[0]?.localStorage.find(({ name }) => {
+  const clientParams = localStorageEntries.find(({ name }) => {
     return name === CLIENT_PARAMS_KEY;
   });
 
@@ -183,8 +208,8 @@ test("token refresh with expired access token", async ({ page }) => {
   await expect(page.getByTestId("access-token-state")).toContainText(initialAccessToken);
 
   // Verify refresh token exists in storage
-  const storage = await page.context().storageState();
-  const accessTokens = storage.origins[0]?.localStorage.find(({ name }) => name === ACCESS_TOKENS_KEY);
+  const localStorageEntries = await getAppLocalStorage(page);
+  const accessTokens = localStorageEntries.find(({ name }) => name === ACCESS_TOKENS_KEY);
   expect(accessTokens).toBeTruthy();
 
   if (accessTokens) {

--- a/test/unit/IdaasClient/handleRedirect.test.ts
+++ b/test/unit/IdaasClient/handleRedirect.test.ts
@@ -32,7 +32,7 @@ describe("IdaasClient.handleRedirect", () => {
     };
   });
   // Mock JWT validation to avoid complex crypto operations in tests
-  const spyOnValidateIdToken = spyOn(jwt, "validateIdToken").mockImplementation(() => {
+  const spyOnValidateIdToken = spyOn(jwt, "validateIdToken").mockImplementation(async () => {
     return { decodedJwt: TEST_ID_TOKEN_OBJECT.decoded, idToken: TEST_ID_TOKEN_OBJECT.encoded };
   });
   const loginSuccessUrl = `${TEST_BASE_URI}?code=${TEST_CODE}&state=${TEST_STATE}`;

--- a/test/unit/constants.ts
+++ b/test/unit/constants.ts
@@ -10,7 +10,7 @@ export const TEST_CLIENT_ID = "testingclientid";
 export const TEST_ID_TOKEN = "testingidtoken";
 export const TEST_NONCE = "testingnonce";
 export const TEST_ISSUER_URI = `${TEST_BASE_URI}/issuer`;
-export const TEST_ID_TOKEN_SIGNING_ALG_SUPPORTED = ["none", "123"];
+export const TEST_ID_TOKEN_SIGNING_ALG_SUPPORTED = ["RS256", "PS256"];
 export const TEST_SCOPE = "openid profile email";
 export const TEST_AUDIENCE = `${TEST_BASE_URI}/audience`;
 export const TEST_ACCESS_TOKEN = "testingaccesstoken";
@@ -96,6 +96,7 @@ export const TEST_VALIDATE_ID_TOKEN_PARAMS: ValidateIdTokenParams = {
   nonce: TEST_NONCE,
   idTokenSigningAlgValuesSupported: TEST_ID_TOKEN_SIGNING_ALG_SUPPORTED,
   acrValuesSupported: TEST_ACR_SUPPORTED,
+  jwksEndpoint: TEST_JWKS_ENDPOINT,
 };
 
 export const TEST_ID_TOKEN_OBJECT: IdToken = {

--- a/test/unit/jwt.test.ts
+++ b/test/unit/jwt.test.ts
@@ -9,136 +9,235 @@ import {
   TEST_VALIDATE_USER_INFO_PARAMS,
 } from "./constants";
 
+const TEST_RS256_HEADER = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
+const TEST_RS256_PAYLOAD = Buffer.from(JSON.stringify(TEST_JWT_PAYLOAD)).toString("base64url");
+const TEST_RS256_TOKEN = `${TEST_RS256_HEADER}.${TEST_RS256_PAYLOAD}.signature`;
+
 describe("jwt.ts", () => {
   describe("validateIdToken", () => {
-    test("throw error if idToken not supplied", () => {
-      expect(() => {
-        validateIdToken({ ...TEST_VALIDATE_ID_TOKEN_PARAMS, idToken: undefined });
-      }).toThrowError("ID");
+    test("throw error if idToken not supplied", async () => {
+      const promise = validateIdToken({ ...TEST_VALIDATE_ID_TOKEN_PARAMS, idToken: undefined });
+      expect(promise).rejects.toThrow("ID");
     });
 
-    test("throw error if idToken is not signed JWT or JSON object", () => {
-      expect(() => {
-        validateIdToken({ ...TEST_VALIDATE_ID_TOKEN_PARAMS, idToken: "notValid" });
-      }).toThrowError("format");
+    test("throw error if idToken is not signed JWT or JSON object", async () => {
+      const promise = validateIdToken({ ...TEST_VALIDATE_ID_TOKEN_PARAMS, idToken: "notValid" });
+      expect(promise).rejects.toThrow("format");
     });
 
-    test("throw error if sub claim missing", () => {
-      expect(() => {
-        validateIdToken({ ...TEST_VALIDATE_ID_TOKEN_PARAMS, idToken: { ...TEST_JWT_PAYLOAD, sub: undefined } });
-      }).toThrowError("sub");
+    test("throw error if sub claim missing", async () => {
+      const promise = validateIdToken({
+        ...TEST_VALIDATE_ID_TOKEN_PARAMS,
+        idToken: { ...TEST_JWT_PAYLOAD, sub: undefined },
+      });
+      expect(promise).rejects.toThrow("sub");
     });
 
-    test("throw error if iat claim missing", () => {
-      expect(() => {
-        validateIdToken({ ...TEST_VALIDATE_ID_TOKEN_PARAMS, idToken: { ...TEST_JWT_PAYLOAD, iat: undefined } });
-      }).toThrowError("iat");
+    test("throw error if iat claim missing", async () => {
+      const promise = validateIdToken({
+        ...TEST_VALIDATE_ID_TOKEN_PARAMS,
+        idToken: { ...TEST_JWT_PAYLOAD, iat: undefined },
+      });
+      expect(promise).rejects.toThrow("iat");
     });
 
-    test("throw error if iss claim missing", () => {
-      expect(() => {
-        validateIdToken({ ...TEST_VALIDATE_ID_TOKEN_PARAMS, idToken: { ...TEST_JWT_PAYLOAD, iss: undefined } });
-      }).toThrowError("iss");
+    test("throw error if iss claim missing", async () => {
+      const promise = validateIdToken({
+        ...TEST_VALIDATE_ID_TOKEN_PARAMS,
+        idToken: { ...TEST_JWT_PAYLOAD, iss: undefined },
+      });
+      expect(promise).rejects.toThrow("iss");
     });
 
-    test("throw error if aud claim missing", () => {
-      expect(() => {
-        validateIdToken({ ...TEST_VALIDATE_ID_TOKEN_PARAMS, idToken: { ...TEST_JWT_PAYLOAD, aud: undefined } });
-      }).toThrowError("aud");
+    test("throw error if aud claim missing", async () => {
+      const promise = validateIdToken({
+        ...TEST_VALIDATE_ID_TOKEN_PARAMS,
+        idToken: { ...TEST_JWT_PAYLOAD, aud: undefined },
+      });
+      expect(promise).rejects.toThrow("aud");
     });
 
-    test("throw error if exp claim missing", () => {
-      expect(() => {
-        validateIdToken({ ...TEST_VALIDATE_ID_TOKEN_PARAMS, idToken: { ...TEST_JWT_PAYLOAD, exp: undefined } });
-      }).toThrowError("exp");
+    test("throw error if exp claim missing", async () => {
+      const promise = validateIdToken({
+        ...TEST_VALIDATE_ID_TOKEN_PARAMS,
+        idToken: { ...TEST_JWT_PAYLOAD, exp: undefined },
+      });
+      expect(promise).rejects.toThrow("exp");
     });
 
-    test("throw error if iss claim does not match expected", () => {
-      expect(() => {
-        validateIdToken({ ...TEST_VALIDATE_ID_TOKEN_PARAMS, idToken: { ...TEST_JWT_PAYLOAD, iss: "different" } });
-      }).toThrowError("iss");
+    test("throw error if iss claim does not match expected", async () => {
+      const promise = validateIdToken({
+        ...TEST_VALIDATE_ID_TOKEN_PARAMS,
+        idToken: { ...TEST_JWT_PAYLOAD, iss: "different" },
+      });
+      expect(promise).rejects.toThrow("iss");
     });
 
-    test("throw error if aud claim as string does not match expected", () => {
-      expect(() => {
-        validateIdToken({ ...TEST_VALIDATE_ID_TOKEN_PARAMS, idToken: { ...TEST_JWT_PAYLOAD, aud: "different" } });
-      }).toThrowError("aud");
+    test("throw error if aud claim as string does not match expected", async () => {
+      const promise = validateIdToken({
+        ...TEST_VALIDATE_ID_TOKEN_PARAMS,
+        idToken: { ...TEST_JWT_PAYLOAD, aud: "different" },
+      });
+      expect(promise).rejects.toThrow("aud");
     });
 
-    test("throw error if aud claim as array does not include expected", () => {
-      expect(() => {
-        validateIdToken({ ...TEST_VALIDATE_ID_TOKEN_PARAMS, idToken: { ...TEST_JWT_PAYLOAD, aud: ["different"] } });
-      }).toThrowError("array");
+    test("throw error if aud claim as array does not include expected", async () => {
+      const promise = validateIdToken({
+        ...TEST_VALIDATE_ID_TOKEN_PARAMS,
+        idToken: { ...TEST_JWT_PAYLOAD, aud: ["different"] },
+      });
+      expect(promise).rejects.toThrow("array");
     });
 
-    test("throw error if more than one audience and azp claim is missing", () => {
-      expect(() => {
-        validateIdToken({
-          ...TEST_VALIDATE_ID_TOKEN_PARAMS,
-          idToken: { ...TEST_JWT_PAYLOAD, aud: [TEST_CLIENT_ID, "different"], azp: undefined },
-        });
-      }).toThrowError("azp");
+    test("throw error if more than one audience and azp claim is missing", async () => {
+      const promise = validateIdToken({
+        ...TEST_VALIDATE_ID_TOKEN_PARAMS,
+        idToken: { ...TEST_JWT_PAYLOAD, aud: [TEST_CLIENT_ID, "different"], azp: undefined },
+      });
+      expect(promise).rejects.toThrow("azp");
     });
 
-    test("throw error if more than one audience and azp claim is different than expected", () => {
-      expect(() => {
-        validateIdToken({
-          ...TEST_VALIDATE_ID_TOKEN_PARAMS,
-          idToken: { ...TEST_JWT_PAYLOAD, aud: [TEST_CLIENT_ID, "different"], azp: "different" },
-        });
-      }).toThrowError("match");
+    test("throw error if more than one audience and azp claim is different than expected", async () => {
+      const promise = validateIdToken({
+        ...TEST_VALIDATE_ID_TOKEN_PARAMS,
+        idToken: { ...TEST_JWT_PAYLOAD, aud: [TEST_CLIENT_ID, "different"], azp: "different" },
+      });
+      expect(promise).rejects.toThrow("match");
     });
 
-    test("throw error if alg claim is not supported", () => {
-      expect(() => {
-        validateIdToken({ ...TEST_VALIDATE_ID_TOKEN_PARAMS, idTokenSigningAlgValuesSupported: ["different"] });
-      }).toThrowError("alg");
+    test("throw error if alg claim is not supported", async () => {
+      const promise = validateIdToken({
+        ...TEST_VALIDATE_ID_TOKEN_PARAMS,
+        idToken: TEST_RS256_TOKEN,
+        idTokenSigningAlgValuesSupported: ["PS256"],
+      });
+      expect(promise).rejects.toThrow("alg");
     });
 
-    test("throw error if token is expired", () => {
-      expect(() => {
-        validateIdToken({ ...TEST_VALIDATE_ID_TOKEN_PARAMS, idToken: { ...TEST_JWT_PAYLOAD, exp: 0 } });
-      }).toThrowError("exp");
+    test("throw error if user requested algorithm list excludes token alg", async () => {
+      const promise = validateIdToken({
+        ...TEST_VALIDATE_ID_TOKEN_PARAMS,
+        idToken: TEST_RS256_TOKEN,
+        allowedIdTokenSigningAlgorithms: ["PS256"],
+      });
+      expect(promise).rejects.toThrow("allowed");
     });
 
-    test("token is used before nbf claim", () => {
-      expect(() => {
-        validateIdToken({
-          ...TEST_VALIDATE_ID_TOKEN_PARAMS,
-          idToken: { ...TEST_JWT_PAYLOAD, nbf: Math.floor(Math.floor(Date.now() / 1000) + 60) },
-        });
-      }).toThrowError("nbf");
+    test("throw error if user requested algorithm list contains unsupported algorithm", async () => {
+      const promise = validateIdToken({
+        ...TEST_VALIDATE_ID_TOKEN_PARAMS,
+        idToken: TEST_RS256_TOKEN,
+        allowedIdTokenSigningAlgorithms: ["HS256"],
+      });
+      expect(promise).rejects.toThrow("unsupported");
     });
 
-    test("throw error if nonce claim missing", () => {
-      expect(() => {
-        validateIdToken({ ...TEST_VALIDATE_ID_TOKEN_PARAMS, idToken: { ...TEST_JWT_PAYLOAD, nonce: undefined } });
-      }).toThrowError("nonce");
+    test("throw error if idToken is an unsigned object", async () => {
+      const promise = validateIdToken({
+        ...TEST_VALIDATE_ID_TOKEN_PARAMS,
+        idToken: TEST_JWT_PAYLOAD,
+      });
+      expect(promise).rejects.toThrow("none");
     });
 
-    test("throw error if nonce is different than expected", () => {
-      expect(() => {
-        validateIdToken({ ...TEST_VALIDATE_ID_TOKEN_PARAMS, idToken: { ...TEST_JWT_PAYLOAD, nonce: "different" } });
-      }).toThrowError("match");
+    test("throw error if token is expired", async () => {
+      const promise = validateIdToken({ ...TEST_VALIDATE_ID_TOKEN_PARAMS, idToken: { ...TEST_JWT_PAYLOAD, exp: 0 } });
+      expect(promise).rejects.toThrow("exp");
     });
 
-    test("throw error if acr claim is not supported", () => {
-      expect(() => {
-        validateIdToken({ ...TEST_VALIDATE_ID_TOKEN_PARAMS, idToken: { ...TEST_JWT_PAYLOAD, acr: "different" } });
-      }).toThrowError("supported");
+    test("throw error if iat claim is in the future", async () => {
+      const promise = validateIdToken({
+        ...TEST_VALIDATE_ID_TOKEN_PARAMS,
+        idToken: { ...TEST_JWT_PAYLOAD, iat: Math.floor(Date.now() / 1000) + 60 },
+      });
+      expect(promise).rejects.toThrow("iat");
     });
 
-    test("successful validation with single aud returns a decoded id token and an encoded id token", () => {
-      const result = validateIdToken(TEST_VALIDATE_ID_TOKEN_PARAMS);
+    test("throw error if iat claim is not a valid number", async () => {
+      const promise = validateIdToken({
+        ...TEST_VALIDATE_ID_TOKEN_PARAMS,
+        idToken: { ...TEST_JWT_PAYLOAD, iat: Number.POSITIVE_INFINITY },
+      });
+      expect(promise).rejects.toThrow("numeric");
+    });
+
+    test("throw error if iat claim is after exp claim", async () => {
+      const promise = validateIdToken({
+        ...TEST_VALIDATE_ID_TOKEN_PARAMS,
+        idToken: {
+          ...TEST_JWT_PAYLOAD,
+          iat: Math.floor(Date.now() / 1000) + 120,
+          exp: Math.floor(Date.now() / 1000) + 60,
+        },
+      });
+      expect(promise).rejects.toThrow("later than");
+    });
+
+    test("token is used before nbf claim", async () => {
+      const promise = validateIdToken({
+        ...TEST_VALIDATE_ID_TOKEN_PARAMS,
+        idToken: { ...TEST_JWT_PAYLOAD, nbf: Math.floor(Math.floor(Date.now() / 1000) + 60) },
+      });
+      expect(promise).rejects.toThrow("nbf");
+    });
+
+    test("throw error if nonce claim missing", async () => {
+      const promise = validateIdToken({
+        ...TEST_VALIDATE_ID_TOKEN_PARAMS,
+        idToken: { ...TEST_JWT_PAYLOAD, nonce: undefined },
+      });
+      expect(promise).rejects.toThrow("nonce");
+    });
+
+    test("throw error if nonce is different than expected", async () => {
+      const promise = validateIdToken({
+        ...TEST_VALIDATE_ID_TOKEN_PARAMS,
+        idToken: { ...TEST_JWT_PAYLOAD, nonce: "different" },
+      });
+      expect(promise).rejects.toThrow("match");
+    });
+
+    test("throw error if acr claim is not supported", async () => {
+      const promise = validateIdToken({
+        ...TEST_VALIDATE_ID_TOKEN_PARAMS,
+        idToken: { ...TEST_JWT_PAYLOAD, acr: "different" },
+      });
+      expect(promise).rejects.toThrow("supported");
+    });
+
+    test("successful validation with single aud returns a decoded id token and an encoded id token", async () => {
+      // Mock createRemoteJWKSet to avoid network requests during signature verification.
+      // @ts-expect-error - simplified mock implementation for testing
+      const _spyOnCreateRemoteJWKSet = spyOn(jose, "createRemoteJWKSet").mockImplementationOnce(() => {
+        return async () => ({ keys: [] });
+      });
+
+      const _spyOnJwtVerify = spyOn(jose, "jwtVerify").mockImplementationOnce(
+        // @ts-expect-error not full return type
+        async () => ({ payload: TEST_JWT_PAYLOAD }),
+      );
+
+      const result = await validateIdToken({ ...TEST_VALIDATE_ID_TOKEN_PARAMS, idToken: TEST_RS256_TOKEN });
 
       expect(typeof result.idToken).toBe("string");
       expect(result.decodedJwt.sub).toBeTruthy();
     });
 
-    test("successful validation with multiple aud returns a decoded id token and an encoded id token", () => {
-      const result = validateIdToken({
+    test("successful validation with multiple aud returns a decoded id token and an encoded id token", async () => {
+      // Mock createRemoteJWKSet to avoid network requests during signature verification.
+      // @ts-expect-error - simplified mock implementation for testing
+      const _spyOnCreateRemoteJWKSet = spyOn(jose, "createRemoteJWKSet").mockImplementationOnce(() => {
+        return async () => ({ keys: [] });
+      });
+
+      const _spyOnJwtVerify = spyOn(jose, "jwtVerify").mockImplementationOnce(
+        // @ts-expect-error not full return type
+        async () => ({ payload: { ...TEST_JWT_PAYLOAD, aud: [TEST_CLIENT_ID, "different"] } }),
+      );
+
+      const result = await validateIdToken({
         ...TEST_VALIDATE_ID_TOKEN_PARAMS,
-        idToken: { ...TEST_JWT_PAYLOAD, aud: [TEST_CLIENT_ID, "different"] },
+        idToken: `${TEST_RS256_HEADER}.${Buffer.from(JSON.stringify({ ...TEST_JWT_PAYLOAD, aud: [TEST_CLIENT_ID, "different"] })).toString("base64url")}.signature`,
       });
 
       expect(typeof result.idToken).toBe("string");


### PR DESCRIPTION
This PR strengthens ID token validation in the OIDC authorization code flow by adding JWT signature verification against the OpenID Provider JWKS endpoint, in addition to existing claim checks. A prior review identified that relying on TLS for ID token integrity was an assumption rather than an enforced guarantee in code. While OIDC allows skipping signature verification in some authorization code flow scenarios over trusted TLS, this PR removes that implicit trust assumption by adding explicit cryptographic verification of the ID token signature.

