### PR TITLE
fix: update IDaaS API download URL and add error handling

### DIFF
--- a/scripts/download.ts
+++ b/scripts/download.ts
@@ -4,7 +4,11 @@
 (async () => {
   console.log("Downloading latest IDaaS Authentication OpenAPI file...");
 
-  const response = await fetch("https://entrust.us.trustedauth.com/help/developer/openapi/authentication.json");
+  const response = await fetch("https://docs.trustedauth.com/openapi/authentication.json");
+
+  if (!response.ok) {
+    throw new Error(`Failed to download OpenAPI spec: ${response.status} ${response.statusText}`);
+  }
 
   await Bun.write("authentication.json", response);
 


### PR DESCRIPTION
The previous download URL (`entrust.us.trustedauth.com`) now returns a 404, causing `authentication.json` to be overwritten with an HTML error page. This silently broke the `new-version.yml` workflow, producing PRs with a truncated title (`feat: update IDaaS API to v`).

## Changes
- Updated download URL to `https://docs.trustedauth.com/openapi/authentication.json`
- Added `response.ok` check to fail loudly if the download returns a non-OK response

## Related
Fixes the bad PR opened by the workflow: #353