### PR TITLE
fix: resolve CI build failures in lint:types and lint:knip steps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -39,6 +39,9 @@
       ],
     },
   },
+  "overrides": {
+    "fflate": "0.8.2",
+  },
   "packages": {
     "@andrewbranch/untar.js": ["@andrewbranch/untar.js@1.0.3", "", {}, "sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw=="],
 
@@ -510,7 +513,7 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
-    "fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
+    "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
 
     "formatly": ["formatly@0.3.0", "", { "dependencies": { "fd-package-json": "^2.0.0" }, "bin": { "formatly": "bin/index.mjs" } }, "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -3,7 +3,7 @@
 linker = "isolated"
 
 [test]
-preload = "./happydom.ts"
+preload = ["./happydom.ts"]
 coverage = true
 root = "./test/unit"
 coveragePathIgnorePatterns = [

--- a/package.json
+++ b/package.json
@@ -63,6 +63,9 @@
     "test:manual": "bun run test/test-manual/app.ts",
     "postinstall": "bun run api:generate"
   },
+  "overrides": {
+    "fflate": "0.8.2"
+  },
   "dependencies": {
     "jose": "^6.1.0"
   },


### PR DESCRIPTION
## Problem

The `Build and Test` CI check has been failing on every build since ~May 18th, blocking all PRs now that the branch ruleset requires it to pass.

Two issues found:

### 1. `attw` crash in `lint:types` (`Cannot read properties of undefined (reading 'filename')`)
`fflate@0.8.3` introduced a bug that causes `@arethetypeswrong/cli@0.18.2` to crash. Fixed by pinning `fflate` to `0.8.2` via `overrides` until a patched `attw` release is available.

See: https://github.com/arethetypeswrong/arethetypeswrong.github.io/issues/258

### 2. `bunfig.toml` preload warning in `lint:knip`
Newer versions of Bun expect `preload` to be an array. Changed `preload = "./happydom.ts"` → `preload = ["./happydom.ts"]`.

## Changes
- `bunfig.toml`: use array syntax for `preload`
- `package.json`: add `overrides.fflate = "0.8.2"`
- `bun.lock`: updated to reflect fflate override