### PR TITLE
chore: run api:generate and docs:generate in new-version workflow

### DIFF
--- a/.github/workflows/new-version.yml
+++ b/.github/workflows/new-version.yml
@@ -12,6 +12,8 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       - run: bun install --frozen-lockfile
       - run: bun run api:download
+      - run: bun run api:generate
+      - run: bun run docs:generate
       - name: Extract API version
         id: version
         run: echo "api_version=$(jq -r '.info.version' authentication.json)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Automated API update PRs were missing regenerated types and docs, causing the `Build and Test` CI check to fail on the docs freshness step.

This adds `api:generate` and `docs:generate` steps after `api:download` so the PR includes everything up to date before CI runs.

Fixes the issue seen in #361.