### PR TITLE
feat: implement fail-fast ACR validation for access tokens across aut…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -470,13 +470,13 @@ Specify required authentication strength:
 // Require knowledge-based authentication
 await client.login({
   popup: true,
-  acrValues: ["knowledge"] // e.g., password, KBA
+  acrValues: "knowledge" // e.g., password, KBA
 });
 
 // Require possession-based authentication
 await client.login({
   popup: true,
-  acrValues: ["possession"] // e.g., OTP, soft token
+  acrValues: "possession" // e.g., OTP, soft token
 });
 ```
 
@@ -509,6 +509,8 @@ await client.rba.requestChallenge(
   }
 );
 ```
+
+When `acrValues` is requested, token completion now fails fast if the returned access token `acr` claim is missing or does not match one of the requested values.
 
 ### Pattern: Transaction Details for RBA
 

--- a/docs/guides/oidc.md
+++ b/docs/guides/oidc.md
@@ -110,6 +110,7 @@ await fetch("https://api.example.com/me", {
 - `getAccessToken(options?)` gets the locally stored access token, or issues a refresh-token grant if needed (when refresh tokens are enabled).
 - `getIdTokenClaims()` returns decoded claims or `null` if no ID token is stored.
 - `isAuthenticated()` returns `true` when valid tokens are cached.
+- If `tokenOptions.acrValues` is provided during login, token processing fails fast when the returned access token `acr` claim is missing or does not match one of the requested values.
 
 ## Logout
 
@@ -139,6 +140,7 @@ Common issues:
 
 - **Popup blocked** – use redirect flow or instruct users to allow popups.
 - **`invalid_redirect_uri`** – confirm the URI matches the OIDC application configuration.
+- **ACR mismatch during login** – if you request `acrValues`, ensure your IDaaS policy can return an access token whose `acr` satisfies one of those values.
 
 ## Testing tip
 

--- a/docs/guides/rba.md
+++ b/docs/guides/rba.md
@@ -85,6 +85,8 @@ await idaas.rba.requestChallenge(
 );
 ```
 
+When `tokenOptions.acrValues` is provided, the SDK validates that the returned access token `acr` claim satisfies one of the requested values. If the `acr` claim is missing or does not match, the flow fails and throws.
+
 ## Rendering the challenge
 
 Use the response payload to decide what UI to show. For example, if `challenge.method === "OTP"` display an input for the code; if it’s `"PASSKEY"` trigger a WebAuthn ceremony.
@@ -112,6 +114,8 @@ You must use different properties for KBA & Passkey submissions.
 
 `submitChallenge` returns an `AuthenticationResponse` containing tokens (when the flow ends immediately) or a status update instructing you to poll.
 
+If `acrValues` was requested for the transaction, token completion fails fast if the returned access token `acr` does not satisfy the requested values.
+
 ## Polling asynchronous methods
 
 Some authenticators (push, face) require user action on another device. Use `poll` to check status until the user completes the task or the transaction times out.
@@ -125,6 +129,8 @@ try {
 ```
 
 `poll` returns the same `AuthenticationResponse` shape. Stop polling when status equals `COMPLETED`, `FAILED`, or `CANCELLED`.
+
+If polling completes authentication and `acrValues` was requested, token completion still enforces the same `acr` validation rules.
 
 ## Cancelling a transaction
 

--- a/docs/guides/step-up.md
+++ b/docs/guides/step-up.md
@@ -40,6 +40,8 @@ Choose your approach:
 - Hosted path: wait for login completion, then call `getAccessToken(stepUpTokenOptions)`.
 - Hosted redirect mode: complete `idaas.oidc.handleRedirect()` before calling `getAccessToken(stepUpTokenOptions)`.
 
+If `stepUpTokenOptions.acrValues` is present, the SDK enforces fail-fast ACR validation while processing returned tokens. The flow throws when the returned access token `acr` claim is missing or does not satisfy any requested value.
+
 5. Retry the protected API call with the upgraded token.
 
 ## Sequence diagram

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -15,11 +15,13 @@ This guide lists common issues encountered when integrating the IDaaS Auth JS SD
 
 ## Hosted OIDC flows (`oidc`)
 
-| Symptom                                    | Likely cause                                                                         | Fix                                                                                              |
-| ------------------------------------------ | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
-| Popup window blocked or immediately closed | Browser blocked popups.                                                              | Switch to redirect flow (`popup: false`) or ask users to allow popups for your domain.           |
-| `invalid_redirect_uri` error               | Redirect URI sent by SDK isn’t registered.                                           | Update the tenant app configuration or pass the correct `redirectUri` to `login`.                |
-| `state mismatch`/`invalid_state`           | Callback handled without original state (e.g., multiple clients or double handling). | Use a single `IdaasClient` instance per request and call `handleRedirect()` only once per login. |
+| Symptom                                                                 | Likely cause                                                                         | Fix                                                                                              |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| Popup window blocked or immediately closed                              | Browser blocked popups.                                                              | Switch to redirect flow (`popup: false`) or ask users to allow popups for your domain.           |
+| `invalid_redirect_uri` error                                            | Redirect URI sent by SDK isn’t registered.                                           | Update the tenant app configuration or pass the correct `redirectUri` to `login`.                |
+| `state mismatch`/`invalid_state`                                        | Callback handled without original state (e.g., multiple clients or double handling). | Use a single `IdaasClient` instance per request and call `handleRedirect()` only once per login. |
+| `Returned access token is missing the acr claim...`                     | `acrValues` was requested, but returned token had no `acr` claim.                    | Confirm tenant policy emits `acr` for the requested flow, or request compatible `acrValues`.     |
+| `Returned access token acr ... does not satisfy requested acrValues...` | `acrValues` requested does not match authentication result.                          | Adjust requested `acrValues` or tenant policy so at least one requested value can be returned.   |
 
 ---
 
@@ -34,13 +36,14 @@ This guide lists common issues encountered when integrating the IDaaS Auth JS SD
 
 ## RBA / self-hosted flows (`rba`, `auth`)
 
-| Symptom                                      | Likely cause                                                            | Fix                                                                                   |
-| -------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| `userId required` errors                     | Missing first argument on RBA/auth helpers.                             | Supply `userId` (only passkey discoverable flows may omit it).                        |
-| `INVALID_TRANSACTION`                        | Calling `submit`/`poll` after the transaction expired or was cancelled. | Restart with `requestChallenge` or `authenticate*`.                                   |
-| OTP never arrives                            | Wrong delivery channel/attribute.                                       | Specify `otpDeliveryType`/`otpDeliveryAttribute` or update the user profile in IDaaS. |
-| Push/face flows never complete               | No polling or Onfido capture incomplete.                                | Call `auth.poll()`.                                                                   |
-| Passkey flow rejected with `NotAllowedError` | User cancelled the browser prompt or WebAuthn unsupported.              | Prompt the user again or detect support via `browserSupportsPasskey()`.               |
+| Symptom                                      | Likely cause                                                                             | Fix                                                                                     |
+| -------------------------------------------- | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `userId required` errors                     | Missing first argument on RBA/auth helpers.                                              | Supply `userId` (only passkey discoverable flows may omit it).                          |
+| `INVALID_TRANSACTION`                        | Calling `submit`/`poll` after the transaction expired or was cancelled.                  | Restart with `requestChallenge` or `authenticate*`.                                     |
+| OTP never arrives                            | Wrong delivery channel/attribute.                                                        | Specify `otpDeliveryType`/`otpDeliveryAttribute` or update the user profile in IDaaS.   |
+| Push/face flows never complete               | No polling or Onfido capture incomplete.                                                 | Call `auth.poll()`.                                                                     |
+| Passkey flow rejected with `NotAllowedError` | User cancelled the browser prompt or WebAuthn unsupported.                               | Prompt the user again or detect support via `browserSupportsPasskey()`.                 |
+| ACR validation errors on completion          | Transaction requested `acrValues`, but returned token `acr` is missing or not requested. | Align `acrValues` with policy/authenticator outcome so one requested value is returned. |
 
 ---
 

--- a/src/AuthenticationTransaction.ts
+++ b/src/AuthenticationTransaction.ts
@@ -24,6 +24,7 @@ import type {
   UserChallengeParameters,
 } from "./models/openapi-ts";
 import { calculateEpochExpiry } from "./utils/format";
+import { readAccessToken, validateReturnedAccessTokenAcr } from "./utils/jwt";
 import { buildFidoResponse, buildPubKeyRequestOptions } from "./utils/passkey";
 import { generateAuthorizationUrl } from "./utils/url";
 
@@ -335,6 +336,14 @@ export class AuthenticationTransaction {
       throw new Error("failed to fetch refresh token from IDaaS");
     }
 
+    const decodedAccessToken = readAccessToken(access_token as string);
+    const acr = decodedAccessToken?.acr;
+
+    validateReturnedAccessTokenAcr({
+      requestedAcrValues: this.#tokenOptions.acrValues,
+      returnedAcr: acr,
+    });
+
     this.#authenticationDetails = {
       ...this.#authenticationDetails,
       idToken: id_token as string | undefined,
@@ -343,7 +352,7 @@ export class AuthenticationTransaction {
       expiresAt: calculateEpochExpiry(expires_in),
       audience: this.#tokenOptions.audience,
       maxAge: this.#tokenOptions.maxAge,
-      acr: this.#tokenOptions.acrValues,
+      acr,
     };
   };
 

--- a/src/OidcClient.ts
+++ b/src/OidcClient.ts
@@ -5,7 +5,7 @@ import type { AuthorizeResponse, OidcLoginOptions, OidcLogoutOptions, TokenOptio
 import type { AccessToken, StorageManager, TokenParams } from "./storage/StorageManager";
 import { listenToAuthorizePopup, openPopup } from "./utils/browser";
 import { calculateEpochExpiry, formatUrl, sanitizeUri } from "./utils/format";
-import { readAccessToken, validateIdToken } from "./utils/jwt";
+import { readAccessToken, validateIdToken, validateReturnedAccessTokenAcr } from "./utils/jwt";
 import { generateAuthorizationUrl } from "./utils/url";
 
 /**
@@ -262,7 +262,8 @@ export class OidcClient {
   #parseAndSaveTokenResponse(validatedTokenResponse: ValidatedTokenResponse, tokenParams: TokenParams): void {
     const { tokenResponse, decodedIdToken, encodedIdToken } = validatedTokenResponse;
     const { refresh_token, access_token, expires_in } = tokenResponse;
-    const authTime = readAccessToken(access_token)?.auth_time;
+    const decodedAccessToken = readAccessToken(access_token);
+    const authTime = decodedAccessToken?.auth_time;
     const expiresAt = calculateEpochExpiry(expires_in, authTime);
 
     const { audience, scope, maxAge } = tokenParams;
@@ -270,8 +271,12 @@ export class OidcClient {
 
     this.#storageManager.removeTokenParams();
 
-    const token = readAccessToken(access_token);
-    const acr = token?.acr ?? undefined;
+    const acr = decodedAccessToken?.acr ?? undefined;
+
+    validateReturnedAccessTokenAcr({
+      requestedAcrValues: tokenParams.acrValue,
+      returnedAcr: acr,
+    });
 
     const newAccessToken: AccessToken = {
       refreshToken: refresh_token,
@@ -318,6 +323,11 @@ export class OidcClient {
       scope: usedScope,
       requireIdToken: (tokenOptions.includeOpenidScope ?? this.#context.tokenOptions.includeOpenidScope) !== false,
     };
+
+    const acrValues = tokenOptions.acrValues ?? this.#context.tokenOptions.acrValues;
+    if (acrValues && acrValues.trim().length > 0) {
+      tokenParams.acrValue = acrValues;
+    }
 
     if (tokenOptions.maxAge !== undefined && tokenOptions.maxAge >= 0) {
       tokenParams.maxAge = tokenOptions.maxAge;
@@ -371,6 +381,11 @@ export class OidcClient {
       scope: usedScope,
       requireIdToken: (tokenOptions.includeOpenidScope ?? this.#context.tokenOptions.includeOpenidScope) !== false,
     };
+
+    const acrValues = tokenOptions.acrValues ?? this.#context.tokenOptions.acrValues;
+    if (acrValues && acrValues.trim().length > 0) {
+      tokenParams.acrValue = acrValues;
+    }
 
     if (tokenOptions.maxAge !== undefined && tokenOptions.maxAge >= 0) {
       tokenParams.maxAge = tokenOptions.maxAge;

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -29,6 +29,11 @@ export interface DecodedAccessToken {
   jti: string;
 }
 
+interface ValidateReturnedAccessTokenAcrParams {
+  requestedAcrValues?: string;
+  returnedAcr?: string;
+}
+
 /**
  * Validate the signed ID token received from the /token endpoint in accordance with the OIDC specification.
  *
@@ -213,4 +218,37 @@ export const readAccessToken = (encodedToken: string): DecodedAccessToken | null
     return null;
   }
   return decodedToken;
+};
+
+/**
+ * Ensures that the returned access token ACR satisfies the requested ACR values.
+ */
+export const validateReturnedAccessTokenAcr = ({
+  requestedAcrValues,
+  returnedAcr,
+}: ValidateReturnedAccessTokenAcrParams): void => {
+  const requestedAcrValuesAsString = requestedAcrValues?.trim() ?? "";
+
+  // No ACR constraints were requested.
+  if (requestedAcrValuesAsString.length === 0) {
+    return;
+  }
+
+  const requestedAcrs = requestedAcrValuesAsString.split(" ").filter(Boolean);
+
+  if (requestedAcrs.length === 0) {
+    return;
+  }
+
+  if (!returnedAcr) {
+    throw new Error(
+      `Returned access token is missing the acr claim for requested acrValues: "${requestedAcrValuesAsString}"`,
+    );
+  }
+
+  if (!requestedAcrs.includes(returnedAcr)) {
+    throw new Error(
+      `Returned access token acr "${returnedAcr}" does not satisfy requested acrValues: "${requestedAcrValuesAsString}"`,
+    );
+  }
 };

--- a/test/unit/IdaasClient/handleRedirect.test.ts
+++ b/test/unit/IdaasClient/handleRedirect.test.ts
@@ -111,6 +111,56 @@ describe("IdaasClient.handleRedirect", () => {
       }).toThrowError();
     });
 
+    test("throws if requested acrValues are not satisfied by returned access token acr", () => {
+      storeData({ clientParams: true, tokenParams: true });
+      localStorage.setItem(
+        `entrust.${TEST_CLIENT_ID}.tokenParams`,
+        JSON.stringify({ ...TEST_TOKEN_PARAMS, acrValue: "knowledge possession" }),
+      );
+      window.location.href = loginSuccessUrl;
+
+      spyOn(jwt, "readAccessToken").mockImplementationOnce(() => {
+        return {
+          sub: "testingsubclaim",
+          acr: "inherence",
+          nbf: "0",
+          exp: "9999999999",
+          iat: "0",
+          iss: TEST_BASE_URI,
+          jti: "testing-jti",
+        };
+      });
+
+      expect(async () => {
+        await NO_DEFAULT_IDAAS_CLIENT.oidc.handleRedirect();
+      }).toThrowError("does not satisfy requested acrValues");
+    });
+
+    test("throws if acrValues are requested but returned access token acr claim is missing", () => {
+      storeData({ clientParams: true, tokenParams: true });
+      localStorage.setItem(
+        `entrust.${TEST_CLIENT_ID}.tokenParams`,
+        JSON.stringify({ ...TEST_TOKEN_PARAMS, acrValue: "knowledge" }),
+      );
+      window.location.href = loginSuccessUrl;
+
+      spyOn(jwt, "readAccessToken").mockImplementationOnce(() => {
+        return {
+          sub: "testingsubclaim",
+          acr: "",
+          nbf: "0",
+          exp: "9999999999",
+          iat: "0",
+          iss: TEST_BASE_URI,
+          jti: "testing-jti",
+        };
+      });
+
+      expect(async () => {
+        await NO_DEFAULT_IDAAS_CLIENT.oidc.handleRedirect();
+      }).toThrowError("missing the acr claim");
+    });
+
     test("removes tokenParams from storage after processing", async () => {
       storeData({ clientParams: true, tokenParams: true });
       window.location.href = loginSuccessUrl;

--- a/test/unit/IdaasClient/login.test.ts
+++ b/test/unit/IdaasClient/login.test.ts
@@ -95,6 +95,13 @@ describe("IdaasClient.oidc.login", () => {
       expect(localStorage.getItem(TEST_TOKEN_PAIR.key)).toBeTruthy();
     });
 
+    test("token params contain requested acr values", async () => {
+      await NO_DEFAULT_IDAAS_CLIENT.oidc.login({}, { acrValues: "knowledge possession" });
+
+      const tokenParams = JSON.parse(localStorage.getItem(TEST_TOKEN_PAIR.key) as string);
+      expect(tokenParams.acrValue).toBe("knowledge possession");
+    });
+
     test("generates authorization URL with all required parameters", async () => {
       await NO_DEFAULT_IDAAS_CLIENT.oidc.login();
 

--- a/test/unit/jwt.test.ts
+++ b/test/unit/jwt.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, spyOn, test } from "bun:test";
 import * as jose from "jose";
-import { readAccessToken, validateIdToken, validateUserInfoToken } from "../../src/utils/jwt";
+import {
+  readAccessToken,
+  validateIdToken,
+  validateReturnedAccessTokenAcr,
+  validateUserInfoToken,
+} from "../../src/utils/jwt";
 import {
   TEST_CLIENT_ID,
   TEST_ENCODED_TOKEN,
@@ -181,6 +186,44 @@ describe("jwt.ts", () => {
     test("returns null if the passed token is not a JWT", () => {
       const result = readAccessToken("not a JWT");
       expect(result).toBeNull();
+    });
+  });
+
+  describe("validateReturnedAccessTokenAcr", () => {
+    test("does not throw when no acrValues are requested", () => {
+      expect(() => {
+        validateReturnedAccessTokenAcr({
+          requestedAcrValues: "",
+          returnedAcr: undefined,
+        });
+      }).not.toThrow();
+    });
+
+    test("does not throw when returned acr matches any requested acr", () => {
+      expect(() => {
+        validateReturnedAccessTokenAcr({
+          requestedAcrValues: "urn:acr:bronze urn:acr:silver",
+          returnedAcr: "urn:acr:silver",
+        });
+      }).not.toThrow();
+    });
+
+    test("throws when acrValues are requested and returned acr claim is missing", () => {
+      expect(() => {
+        validateReturnedAccessTokenAcr({
+          requestedAcrValues: "knowledge possession",
+          returnedAcr: undefined,
+        });
+      }).toThrowError("missing the acr claim");
+    });
+
+    test("throws when returned acr does not satisfy requested acrValues", () => {
+      expect(() => {
+        validateReturnedAccessTokenAcr({
+          requestedAcrValues: "knowledge possession",
+          returnedAcr: "inherence",
+        });
+      }).toThrowError("does not satisfy requested acrValues");
     });
   });
 });


### PR DESCRIPTION
This PR adds fail-fast ACR enforcement for both OIDC and RBA flows by validating that when tokenOptions.acrValues is requested, the returned access token includes an acr claim that matches at least one requested value; if the acr claim is missing or does not match, the SDK now throws during token processing. Refresh token skips the validation since it only is meant to refresh the same session, but not guaranteed same auth strength unless revalidated.



