### PR TITLE
feat: add support for requested ACR values in ID token validation and…

### DIFF
--- a/src/AuthenticationTransaction.ts
+++ b/src/AuthenticationTransaction.ts
@@ -30,6 +30,7 @@ import { generateAuthorizationUrl } from "./utils/url";
 interface AuthenticationDetails {
   method?: IdaasAuthenticationMethod;
   secondFactor?: IdaasAuthenticationMethod;
+  nonce?: string;
   scope?: string;
   expiresAt?: number;
   idToken?: string;
@@ -82,11 +83,13 @@ export class AuthenticationTransaction {
    */
   public async requestAuthChallenge(): Promise<AuthenticationResponse> {
     // 1. Generate /authorizejwt URL and fetch OIDC details
-    const { url, codeVerifier } = await generateAuthorizationUrl(this.#oidcConfig, {
+    const { url, codeVerifier, nonce } = await generateAuthorizationUrl(this.#oidcConfig, {
       clientId: this.#clientId,
       tokenOptions: this.#tokenOptions,
       type: "jwt",
     });
+
+    this.#authenticationDetails.nonce = nonce;
 
     const { authRequestKey, applicationId } = await getAuthRequestId(url);
 

--- a/src/OidcClient.ts
+++ b/src/OidcClient.ts
@@ -131,6 +131,7 @@ export class OidcClient {
       redirectUri,
       nonce,
       tokenParams.requireIdToken ?? true,
+      tokenParams.acrValues?.split(" ").filter(Boolean),
     );
     this.#parseAndSaveTokenResponse(validatedTokenResponse, tokenParams);
     return null;
@@ -210,6 +211,7 @@ export class OidcClient {
     redirectUri: string,
     nonce: string,
     requireIdToken: boolean,
+    requestedAcrValues?: string[],
   ) {
     const { token_endpoint, id_token_signing_alg_values_supported, acr_values_supported, jwks_uri } =
       await this.#context.getConfig();
@@ -237,6 +239,7 @@ export class OidcClient {
       allowedIdTokenSigningAlgorithms: this.#context.allowedIdTokenSigningAlgorithms,
       acrValuesSupported: acr_values_supported,
       jwksEndpoint: jwks_uri,
+      requestedAcrValues,
     });
 
     return { tokenResponse, decodedIdToken, encodedIdToken: idToken };
@@ -319,6 +322,7 @@ export class OidcClient {
       audience: tokenOptions.audience ?? this.#context.tokenOptions.audience,
       scope: usedScope,
       requireIdToken: (tokenOptions.includeOpenidScope ?? this.#context.tokenOptions.includeOpenidScope) !== false,
+      acrValues: tokenOptions.acrValues ?? this.#context.tokenOptions.acrValues,
     };
 
     if (tokenOptions.maxAge !== undefined && tokenOptions.maxAge >= 0) {
@@ -336,6 +340,7 @@ export class OidcClient {
       finalRedirectUri,
       nonce,
       tokenParams.requireIdToken ?? true,
+      tokenParams.acrValues?.split(" ").filter(Boolean),
     );
 
     this.#parseAndSaveTokenResponse(validatedTokenResponse, tokenParams);
@@ -372,6 +377,7 @@ export class OidcClient {
       audience: tokenOptions.audience ?? this.#context.tokenOptions.audience,
       scope: usedScope,
       requireIdToken: (tokenOptions.includeOpenidScope ?? this.#context.tokenOptions.includeOpenidScope) !== false,
+      acrValues: tokenOptions.acrValues ?? this.#context.tokenOptions.acrValues,
     };
 
     if (tokenOptions.maxAge !== undefined && tokenOptions.maxAge >= 0) {

--- a/src/RbaClient.ts
+++ b/src/RbaClient.ts
@@ -10,6 +10,7 @@ import type {
 } from "./models";
 import type { StorageManager } from "./storage/StorageManager";
 import { calculateEpochExpiry } from "./utils/format";
+import { validateIdToken } from "./utils/jwt";
 
 /**
  * Risk-Based Authentication (RBA) client for self-hosted authentication flows.
@@ -107,7 +108,7 @@ export class RbaClient {
     this.#storageManager.saveIdaasSessionToken({ token: authenticationResponse.token || "" });
 
     if (authenticationResponse.authenticationCompleted) {
-      this.#handleAuthenticationTransactionSuccess();
+      await this.#handleAuthenticationTransactionSuccess();
     }
 
     return authenticationResponse;
@@ -167,7 +168,7 @@ export class RbaClient {
     const authenticationResponse = await this.#authenticationTransaction.pollForAuthCompletion();
 
     if (authenticationResponse.authenticationCompleted) {
-      this.#handleAuthenticationTransactionSuccess();
+      await this.#handleAuthenticationTransactionSuccess();
     }
     return authenticationResponse;
   }
@@ -224,12 +225,12 @@ export class RbaClient {
     });
   };
 
-  #handleAuthenticationTransactionSuccess = () => {
+  #handleAuthenticationTransactionSuccess = async () => {
     if (!this.#authenticationTransaction) {
       throw new Error("No authentication transaction in progress!");
     }
 
-    const { idToken, accessToken, refreshToken, scope, expiresAt, maxAge, audience, acr } =
+    const { idToken, accessToken, refreshToken, scope, expiresAt, maxAge, audience, acr, nonce } =
       this.#authenticationTransaction.getAuthenticationDetails();
 
     // Only require accessToken for OAuth-only flows
@@ -251,9 +252,27 @@ export class RbaClient {
 
     // Save ID token only if present
     if (idToken) {
+      if (!nonce) {
+        throw new Error("Nonce (nonce) claim is missing from ID token validation context");
+      }
+
+      const { id_token_signing_alg_values_supported, acr_values_supported, jwks_uri } = await this.#context.getConfig();
+      const requestedAcrValues = acr?.split(" ").filter(Boolean);
+
+      const { idToken: encodedIdToken, decodedJwt } = await validateIdToken({
+        idToken,
+        issuer: this.#context.issuerUrl,
+        clientId: this.#context.clientId,
+        nonce,
+        idTokenSigningAlgValuesSupported: id_token_signing_alg_values_supported,
+        acrValuesSupported: acr_values_supported,
+        jwksEndpoint: jwks_uri,
+        requestedAcrValues,
+      });
+
       this.#storageManager.saveIdToken({
-        encoded: idToken,
-        decoded: decodeJwt(idToken),
+        encoded: encodedIdToken,
+        decoded: decodedJwt ?? decodeJwt(idToken),
       });
     }
 

--- a/src/storage/StorageManager.ts
+++ b/src/storage/StorageManager.ts
@@ -26,6 +26,7 @@ export interface TokenParams {
   audience?: string;
   scope: string;
   requireIdToken?: boolean;
+  acrValues?: string;
 
   // RFC 9470
   maxAge?: number;

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -26,6 +26,7 @@ export interface ValidateIdTokenParams {
   allowedIdTokenSigningAlgorithms?: string[];
   acrValuesSupported?: string[];
   jwksEndpoint: string;
+  requestedAcrValues?: string[];
 }
 
 export interface ValidateUserInfoTokenParams {
@@ -68,6 +69,7 @@ export const validateIdToken = async ({
   allowedIdTokenSigningAlgorithms,
   acrValuesSupported,
   jwksEndpoint,
+  requestedAcrValues,
 }: ValidateIdTokenParams) => {
   if (!idToken) {
     throw new Error("No ID token supplied");
@@ -244,6 +246,18 @@ export const validateIdToken = async ({
     } catch (error) {
       throw new Error(
         `ID token signature verification failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  if (requestedAcrValues && requestedAcrValues.length > 0) {
+    if (!acrClaim) {
+      throw new Error("Authentication Context Class Reference (acr) claim is missing from ID token");
+    }
+
+    if (typeof acrClaim !== "string" || !requestedAcrValues.includes(acrClaim)) {
+      throw new Error(
+        `Authentication Context Class Reference (acr) claim ${acrClaim} in the ID token is not one of the requested values ${requestedAcrValues}`,
       );
     }
   }

--- a/test/unit/IdaasClient/handleRedirect.test.ts
+++ b/test/unit/IdaasClient/handleRedirect.test.ts
@@ -165,6 +165,20 @@ describe("IdaasClient.handleRedirect", () => {
       expect(storedToken?.encoded).toBeDefined();
     });
 
+    test("passes requested acr values to id token validation", async () => {
+      const requestedAcrValues = "1 2";
+      localStorage.setItem(
+        TEST_TOKEN_PAIR.key,
+        JSON.stringify({ ...TEST_TOKEN_PARAMS, acrValues: requestedAcrValues, requireIdToken: true }),
+      );
+      storeData({ clientParams: true });
+      window.location.href = loginSuccessUrl;
+
+      await NO_DEFAULT_IDAAS_CLIENT.oidc.handleRedirect();
+
+      expect(spyOnValidateIdToken).toHaveBeenCalledWith(expect.objectContaining({ requestedAcrValues: ["1", "2"] }));
+    });
+
     test("preserves existing ID token when openid scope is omitted", async () => {
       const tokenResponseWithoutIdToken = {
         access_token: TEST_ACCESS_TOKEN,

--- a/test/unit/IdaasClient/login.test.ts
+++ b/test/unit/IdaasClient/login.test.ts
@@ -95,6 +95,17 @@ describe("IdaasClient.oidc.login", () => {
       expect(localStorage.getItem(TEST_TOKEN_PAIR.key)).toBeTruthy();
     });
 
+    test("token params include acrValues when acrValues are passed", async () => {
+      const acrValues = `${TEST_ACR_CLAIM} different`;
+      await NO_DEFAULT_IDAAS_CLIENT.oidc.login({}, { acrValues });
+
+      const tokenParamsRaw = localStorage.getItem(TEST_TOKEN_PAIR.key);
+      expect(tokenParamsRaw).toBeTruthy();
+
+      const tokenParams = JSON.parse(tokenParamsRaw as string) as { acrValues?: string };
+      expect(tokenParams.acrValues).toBe(acrValues);
+    });
+
     test("generates authorization URL with all required parameters", async () => {
       await NO_DEFAULT_IDAAS_CLIENT.oidc.login();
 

--- a/test/unit/IdaasClient/rbaCompletion.test.ts
+++ b/test/unit/IdaasClient/rbaCompletion.test.ts
@@ -1,0 +1,133 @@
+import { afterAll, afterEach, describe, expect, jest, spyOn, test } from "bun:test";
+import * as api from "../../../src/api";
+import { IdaasClient } from "../../../src/IdaasClient";
+import * as jwt from "../../../src/utils/jwt";
+import * as urlUtils from "../../../src/utils/url";
+import { TEST_CLIENT_ID, TEST_ISSUER_URI, TEST_OIDC_CONFIG } from "../constants";
+
+describe("IdaasClient.rba completion", () => {
+  // @ts-expect-error non full type
+  const spyOnFetch = spyOn(window, "fetch").mockImplementation(async (url: string) => {
+    if (url === `${TEST_ISSUER_URI}/.well-known/openid-configuration`) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(TEST_OIDC_CONFIG),
+      } as Response);
+    }
+
+    throw new Error(`Unexpected fetch call in test: ${url}`);
+  });
+
+  const spyOnGenerateAuthorizationUrl = spyOn(urlUtils, "generateAuthorizationUrl").mockResolvedValue({
+    url: `${TEST_ISSUER_URI}/authorizejwt?scope=openid%20profile%20email`,
+    nonce: "test-nonce",
+    state: "test-state",
+    codeVerifier: "test-code-verifier",
+    usedScope: "openid profile email",
+  });
+
+  const spyOnGetAuthRequestId = spyOn(api, "getAuthRequestId").mockResolvedValue({
+    authRequestKey: "test-auth-request-key",
+    applicationId: "test-application-id",
+  });
+
+  const spyOnRequestAuthChallenge = spyOn(api, "requestAuthChallenge").mockResolvedValue({
+    token: "challenge-token",
+  } as never);
+
+  const spyOnSubmitAuthChallenge = spyOn(api, "submitAuthChallenge").mockResolvedValue({
+    authenticationCompleted: true,
+    token: "completed-token",
+  } as never);
+
+  const spyOnRequestToken = spyOn(api, "requestToken");
+  const spyOnValidateIdToken = spyOn(jwt, "validateIdToken").mockResolvedValue({
+    idToken: "encoded-id-token",
+    decodedJwt: {
+      sub: "test-sub",
+      nonce: "test-nonce",
+    },
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  test("validates id token with requested acr values when openid scope is included", async () => {
+    const client = new IdaasClient({
+      issuerUrl: TEST_ISSUER_URI,
+      clientId: TEST_CLIENT_ID,
+      storageType: "localstorage",
+    });
+
+    spyOnRequestToken.mockResolvedValueOnce({
+      access_token: "access-token",
+      id_token: "id-token",
+      token_type: "Bearer",
+      expires_in: "300",
+    });
+
+    await client.rba.requestChallenge(
+      {
+        userId: "user@example.com",
+        strict: true,
+        preferredAuthenticationMethod: "PASSWORD",
+      },
+      {
+        acrValues: "1 2",
+      },
+    );
+
+    await client.rba.submitChallenge({ response: "password" });
+
+    expect(spyOnFetch).toHaveBeenCalledTimes(1);
+    expect(spyOnGenerateAuthorizationUrl).toHaveBeenCalledTimes(1);
+    expect(spyOnGetAuthRequestId).toHaveBeenCalledTimes(1);
+    expect(spyOnRequestAuthChallenge).toHaveBeenCalledTimes(1);
+    expect(spyOnSubmitAuthChallenge).toHaveBeenCalledTimes(1);
+    expect(spyOnRequestToken).toHaveBeenCalledTimes(1);
+
+    expect(spyOnValidateIdToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nonce: "test-nonce",
+        requestedAcrValues: ["1", "2"],
+      }),
+    );
+  });
+
+  test("does not validate id token when openid scope is omitted", async () => {
+    const client = new IdaasClient({
+      issuerUrl: TEST_ISSUER_URI,
+      clientId: TEST_CLIENT_ID,
+      storageType: "localstorage",
+    });
+
+    spyOnRequestToken.mockResolvedValueOnce({
+      access_token: "access-token",
+      token_type: "Bearer",
+      expires_in: "300",
+    });
+
+    await client.rba.requestChallenge(
+      {
+        userId: "user@example.com",
+        strict: true,
+        preferredAuthenticationMethod: "PASSWORD",
+      },
+      {
+        includeOpenidScope: false,
+        scope: "profile email",
+      },
+    );
+
+    await client.rba.submitChallenge({ response: "password" });
+
+    expect(spyOnRequestToken).toHaveBeenCalledTimes(1);
+    expect(spyOnValidateIdToken).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/jwt.test.ts
+++ b/test/unit/jwt.test.ts
@@ -12,6 +12,9 @@ import {
 const TEST_RS256_HEADER = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
 const TEST_RS256_PAYLOAD = Buffer.from(JSON.stringify(TEST_JWT_PAYLOAD)).toString("base64url");
 const TEST_RS256_TOKEN = `${TEST_RS256_HEADER}.${TEST_RS256_PAYLOAD}.signature`;
+const createRs256Token = (payload: object) => {
+  return `${TEST_RS256_HEADER}.${Buffer.from(JSON.stringify(payload)).toString("base64url")}.signature`;
+};
 
 describe("jwt.ts", () => {
   describe("validateIdToken", () => {
@@ -203,6 +206,65 @@ describe("jwt.ts", () => {
         idToken: { ...TEST_JWT_PAYLOAD, acr: "different" },
       });
       expect(promise).rejects.toThrow("supported");
+    });
+
+    test("throw error if requested acr values are provided but acr claim is missing", async () => {
+      // @ts-expect-error - simplified mock implementation for testing
+      const _spyOnCreateRemoteJWKSet = spyOn(jose, "createRemoteJWKSet").mockImplementationOnce(() => {
+        return async () => ({ keys: [] });
+      });
+
+      const _spyOnJwtVerify = spyOn(jose, "jwtVerify").mockImplementationOnce(
+        // @ts-expect-error not full return type
+        async () => ({ payload: { ...TEST_JWT_PAYLOAD, acr: undefined } }),
+      );
+
+      const promise = validateIdToken({
+        ...TEST_VALIDATE_ID_TOKEN_PARAMS,
+        idToken: createRs256Token({ ...TEST_JWT_PAYLOAD, acr: undefined }),
+        requestedAcrValues: ["1"],
+      });
+      expect(promise).rejects.toThrow("acr");
+    });
+
+    test("throw error if acr claim is not one of requested acr values", async () => {
+      // @ts-expect-error - simplified mock implementation for testing
+      const _spyOnCreateRemoteJWKSet = spyOn(jose, "createRemoteJWKSet").mockImplementationOnce(() => {
+        return async () => ({ keys: [] });
+      });
+
+      const _spyOnJwtVerify = spyOn(jose, "jwtVerify").mockImplementationOnce(
+        // @ts-expect-error not full return type
+        async () => ({ payload: { ...TEST_JWT_PAYLOAD, acr: "1" } }),
+      );
+
+      const promise = validateIdToken({
+        ...TEST_VALIDATE_ID_TOKEN_PARAMS,
+        idToken: createRs256Token({ ...TEST_JWT_PAYLOAD, acr: "1" }),
+        requestedAcrValues: ["2"],
+      });
+      expect(promise).rejects.toThrow("requested");
+    });
+
+    test("successful validation when acr claim is one of requested acr values", async () => {
+      // @ts-expect-error - simplified mock implementation for testing
+      const _spyOnCreateRemoteJWKSet = spyOn(jose, "createRemoteJWKSet").mockImplementationOnce(() => {
+        return async () => ({ keys: [] });
+      });
+
+      const _spyOnJwtVerify = spyOn(jose, "jwtVerify").mockImplementationOnce(
+        // @ts-expect-error not full return type
+        async () => ({ payload: { ...TEST_JWT_PAYLOAD, acr: "1" } }),
+      );
+
+      const result = await validateIdToken({
+        ...TEST_VALIDATE_ID_TOKEN_PARAMS,
+        idToken: createRs256Token({ ...TEST_JWT_PAYLOAD, acr: "1" }),
+        requestedAcrValues: ["2", "1"],
+      });
+
+      expect(typeof result.idToken).toBe("string");
+      expect(result.decodedJwt.sub).toBeTruthy();
     });
 
     test("successful validation with single aud returns a decoded id token and an encoded id token", async () => {


### PR DESCRIPTION
This PR adds ID token ACR validation when acrValues are requested, ensuring the returned acr claim matches one of the requested values in both OIDC and RBA (jwt_idaas) flows, while preserving OAuth-only behavior by skipping ID token checks when includeOpenidScope is false. It also propagates requested ACR values through redirect/token handling, carries nonce through the RBA transaction so full ID token validation can run there, and includes focused unit test updates covering requested-ACR match/mismatch, missing acr when requested, OIDC redirect propagation, and RBA completion behavior.