### PR TITLE
feat: Add dpop support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ IDaaS Auth JS is the official JavaScript/TypeScript SDK for Entrust Identity-as-
 ### Key features
 
 - Standards-based OIDC authorization-code + PKCE with popup or redirect flows.
+- DPoP-bound token support and `getDpopHeaders()` for DPoP protected resource requests.
 - RFC 9470 and RFC 6750 step-up challenge handling via `parseResponse(response)` for protected API responses.
 - Risk-Based Authentication transaction management with challenge/submit/poll/cancel lifecycle.
 - Convenience authentication methods for passkeys (WebAuthn), password, OTP, soft token, magic link, face, smart credential, grid, KBA, and temporary access codes.
@@ -77,6 +78,32 @@ When `allowedIdTokenSigningAlgorithms` is provided, OIDC login/token exchange va
 
 See the [Quickstart guide](docs/quickstart.md) for configuration options, redirect flows, error handling, and self-hosted examples.
 
+### DPoP protected resource requests
+
+If your API validates DPoP proofs, request a DPoP-bound access token and use `getDpopHeaders()` when calling the protected resource.
+
+```typescript
+const accessToken = await idaas.getAccessToken({
+  audience: "https://api.example.com",
+  scope: "accounts:read",
+  dpop: { alg: "ES256" }
+});
+
+if (!accessToken) {
+  throw new Error("No access token available");
+}
+
+const headers = await idaas.getDpopHeaders({
+  method: "GET",
+  uri: "https://api.example.com/accounts",
+  accessToken
+});
+
+await fetch("https://api.example.com/accounts", { headers });
+```
+
+The protected resource must verify the access token and DPoP proof, including the token `cnf.jkt` binding. See the [DPoP guide](docs/guides/dpop.md) for details.
+
 ---
 
 ## Documentation
@@ -90,6 +117,7 @@ See the [Quickstart guide](docs/quickstart.md) for configuration options, redire
 - [RBA Guide](docs/guides/rba.md)
 - [Convenience Auth Guide](docs/guides/auth.md)
 - [Step-Up Authentication Guide](docs/guides/step-up.md)
+- [DPoP Protected Resource Requests](docs/guides/dpop.md)
 - [AWS API Gateway Integration](docs/guides/aws-api-gateway.md)
 - [JWT IDaaS Grant Type](docs/guides/jwt-idaas-grant.md)
 - [Self-Hosted UI Examples](docs/self-hosted.md)

--- a/biome.json
+++ b/biome.json
@@ -15,7 +15,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "preset": "recommended",
+      "recommended": true,
       "correctness": {
         "useParseIntRadix": "off"
       },

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,12 @@ Use `oidc` when you want Entrust to host the whole login: it handles PKCE, redir
 - Access/refresh/ID tokens persist through `StorageManager`.
 - `useRefreshToken` enables refresh token requests by default.
 - `getAccessToken()` refreshes expired access tokens automatically when a refresh token exists.
+- `getDpopHeaders()` creates DPoP request headers for stored DPoP-bound access tokens.
 - Call `logout()` to wipe cached credentials.
+
+## DPoP API surface
+
+Use `TokenOptions.dpop` to request DPoP-bound tokens during OIDC, RBA, token refresh, and SDK-managed UserInfo calls. Use `getDpopHeaders()` when your application needs to call its own DPoP protected resource. See [DPoP Protected Resource Requests](guides/dpop.md) for the API details and resource server verification requirements.
 
 ## Next steps
 
@@ -44,6 +49,7 @@ Use `oidc` when you want Entrust to host the whole login: it handles PKCE, redir
   - [RBA Guide](guides/rba.md)
   - [Convenience Auth Guide](guides/auth.md)
   - [Step-Up Authentication Guide](guides/step-up.md)
+  - [DPoP Protected Resource Requests](guides/dpop.md)
   - [JWT IDaaS Grant Type (`jwt_idaas`)](guides/jwt-idaas-grant.md)
   - [AWS API Gateway Integration](guides/aws-api-gateway.md) - Complete guide for protecting AWS APIs with IDaaS authentication
 - Reference generated types in the [API Reference](api/README.md).

--- a/docs/api/IdaasClient/classes/IdaasClient.md
+++ b/docs/api/IdaasClient/classes/IdaasClient.md
@@ -165,6 +165,31 @@ Error if the refresh/token exchange fails
 
 ---
 
+### getDpopHeaders()
+
+> **getDpopHeaders**(`options`): `Promise`\<`Record`\<`string`, `string`\>\>
+
+Creates DPoP Authorization headers for a protected resource request.
+
+This returns both `Authorization: DPoP ...` and a signed `DPoP` proof header using
+the key material associated with the selected DPoP-bound access token.
+
+#### Parameters
+
+##### options
+
+[`DpopHeadersOptions`](../../index/interfaces/DpopHeadersOptions.md)
+
+Protected resource request details and optional token lookup options
+
+#### Returns
+
+`Promise`\<`Record`\<`string`, `string`\>\>
+
+DPoP headers to include with the protected resource request
+
+---
+
 ### getIdTokenClaims()
 
 > **getIdTokenClaims**(): [`UserClaims`](../../index/interfaces/UserClaims.md) \| `null`
@@ -184,7 +209,7 @@ Decoded ID token claims, or `null` if no ID token exists
 
 ### getUserInfo()
 
-> **getUserInfo**(`accessToken?`): `Promise`\<[`UserClaims`](../../index/interfaces/UserClaims.md) \| `null`\>
+> **getUserInfo**(`accessToken?`, `tokenOptions?`): `Promise`\<[`UserClaims`](../../index/interfaces/UserClaims.md) \| `null`\>
 
 Retrieves user claims from the OpenID Provider using the userinfo endpoint.
 
@@ -200,6 +225,10 @@ This method fetches fresh user information from the identity provider, as oppose
 Optional access token to use. When provided, its scopes determine the claims
 returned from the userinfo endpoint. If not provided, the access token with default scopes and
 audience will be used if available.
+
+##### tokenOptions?
+
+[`TokenOptions`](../../index/interfaces/TokenOptions.md) = `{}`
 
 #### Returns
 

--- a/docs/api/index/README.md
+++ b/docs/api/index/README.md
@@ -11,6 +11,8 @@
 - [AuthenticationRequestParams](interfaces/AuthenticationRequestParams.md)
 - [AuthenticationResponse](interfaces/AuthenticationResponse.md)
 - [AuthenticationSubmissionParams](interfaces/AuthenticationSubmissionParams.md)
+- [DpopHeadersOptions](interfaces/DpopHeadersOptions.md)
+- [DPoPOptions](interfaces/DPoPOptions.md)
 - [FaceBiometricOptions](interfaces/FaceBiometricOptions.md)
 - [IdaasClientOptions](interfaces/IdaasClientOptions.md)
 - [OidcLoginOptions](interfaces/OidcLoginOptions.md)

--- a/docs/api/index/interfaces/DPoPOptions.md
+++ b/docs/api/index/interfaces/DPoPOptions.md
@@ -1,0 +1,31 @@
+[**@entrustcorp/idaas-auth-js**](../../README.md)
+
+---
+
+[@entrustcorp/idaas-auth-js](../../README.md) / [index](../README.md) / DPoPOptions
+
+# Interface: DPoPOptions
+
+DPoP (Demonstration of Proof-of-Possession) options.
+
+## Properties
+
+### alg
+
+> **alg**: `"ES256"` \| `"ES384"` \| `"ES512"` \| `"PS256"` \| `"PS384"` \| `"PS512"` \| `"RS256"` \| `"RS384"` \| `"RS512"`
+
+Signing algorithm used for DPoP proof JWTs.
+
+---
+
+### includeJkt?
+
+> `optional` **includeJkt?**: `boolean`
+
+When `true`, includes `dpop_jkt` in authorization requests.
+
+#### Default
+
+```ts
+false;
+```

--- a/docs/api/index/interfaces/DpopHeadersOptions.md
+++ b/docs/api/index/interfaces/DpopHeadersOptions.md
@@ -1,0 +1,41 @@
+[**@entrustcorp/idaas-auth-js**](../../README.md)
+
+---
+
+[@entrustcorp/idaas-auth-js](../../README.md) / [index](../README.md) / DpopHeadersOptions
+
+# Interface: DpopHeadersOptions
+
+Options for creating DPoP Authorization headers for a protected resource request.
+
+## Properties
+
+### accessToken?
+
+> `optional` **accessToken?**: `string`
+
+Optional access token to use. If omitted, the SDK retrieves one using `tokenOptions`.
+
+---
+
+### method
+
+> **method**: `string`
+
+HTTP method that will be used for the protected resource request.
+
+---
+
+### tokenOptions?
+
+> `optional` **tokenOptions?**: [`TokenOptions`](TokenOptions.md)
+
+Token lookup options used when `accessToken` is omitted.
+
+---
+
+### uri
+
+> **uri**: `string`
+
+Absolute HTTP or HTTPS URI that will be used for the protected resource request.

--- a/docs/api/index/interfaces/TokenOptions.md
+++ b/docs/api/index/interfaces/TokenOptions.md
@@ -28,6 +28,17 @@ Per OIDC spec, this parameter is optional and will be omitted from the authoriza
 
 ---
 
+### dpop?
+
+> `optional` **dpop?**: [`DPoPOptions`](DPoPOptions.md)
+
+DPoP (Demonstration of Proof-of-Possession) configuration.
+
+Omit this field to disable DPoP.
+Provide an object to enable DPoP.
+
+---
+
 ### includeOpenidScope?
 
 > `optional` **includeOpenidScope?**: `boolean`

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -41,6 +41,11 @@ This section contains comprehensive guides for implementing authentication with 
   - Re-run authentication with required token constraints
   - Retry protected API operations with upgraded tokens
 
+- **[DPoP Protected Resource Requests](./dpop.md)** - Call APIs that enforce RFC 9449 proof-of-possession access tokens
+  - Request DPoP-bound access tokens
+  - Create DPoP request headers with `getDpopHeaders()`
+  - Understand protected resource verification requirements
+
 ## Security
 
 - **[Security Best Practices](./security-best-practices.md)** - Comprehensive security guidance for production deployments

--- a/docs/guides/dpop.md
+++ b/docs/guides/dpop.md
@@ -1,0 +1,141 @@
+# DPoP Protected Resource Requests
+
+DPoP (Demonstration of Proof-of-Possession) binds an access token to a browser-held private key. This reduces the value of a stolen access token because the token must be presented with a signed proof from the matching key.
+
+Use DPoP when your protected API or resource server validates RFC 9449 DPoP proofs. The SDK can acquire DPoP-bound tokens and create the client request headers, but the protected resource must enforce DPoP on the server side.
+
+## SDK APIs for DPoP
+
+DPoP support is exposed through token options and one DPoP-specific request helper.
+
+### `TokenOptions.dpop`
+
+Pass `dpop` anywhere the SDK accepts `TokenOptions` to request or use DPoP for that operation:
+
+- `new IdaasClient(clientOptions, tokenOptions)` for default token behavior.
+- `idaas.oidc.login(loginOptions, tokenOptions)` for hosted OIDC login.
+- `idaas.rba.requestChallenge(authenticationRequestParams, tokenOptions)` for RBA authentication.
+- `idaas.getAccessToken(tokenOptions)` for access-token lookup and refresh.
+- `idaas.getUserInfo(accessToken, tokenOptions)` for SDK-managed UserInfo calls.
+
+```typescript
+const tokenOptions = {
+  audience: "https://api.example.com",
+  scope: "accounts:read",
+  dpop: { alg: "ES256" }
+};
+```
+
+The `dpop` object supports:
+
+- `alg`: the signing algorithm for DPoP proof JWTs.
+- `includeJkt`: when `true`, includes `dpop_jkt` in authorization requests that support it.
+
+### `getDpopHeaders()`
+
+Use `getDpopHeaders()` when your application calls its own DPoP protected resource. This method creates request headers for an existing DPoP-bound access token.
+
+```typescript
+const headers = await idaas.getDpopHeaders({
+  method: "GET",
+  uri: "https://api.example.com/accounts",
+  accessToken
+});
+```
+
+The method is intentionally DPoP-only. It does not return Bearer headers and does not create a new DPoP key for a Bearer token. The selected access token must already be stored by the SDK as DPoP-bound so the SDK can restore the key material referenced by that token.
+
+### Exported types
+
+The SDK exports these DPoP-related types:
+
+- `DPoPOptions`: the shape of `TokenOptions.dpop`.
+- `DpopHeadersOptions`: the parameter type for `getDpopHeaders()`.
+
+## Request a DPoP-bound token
+
+Pass `dpop` in token options when starting authentication or requesting an access token.
+
+```typescript
+await idaas.oidc.login(
+  { popup: true },
+  {
+    audience: "https://api.example.com",
+    scope: "openid profile email accounts:read",
+    dpop: { alg: "ES256", includeJkt: true }
+  }
+);
+
+const accessToken = await idaas.getAccessToken({
+  audience: "https://api.example.com",
+  scope: "accounts:read",
+  dpop: { alg: "ES256" }
+});
+```
+
+When DPoP is enabled, the SDK creates key material in the browser, stores the private key as non-extractable key material, and stores a reference to that key with the DPoP-bound access token. DPoP-enabled token flows require IndexedDB so the SDK can persist that key reference alongside the access token. If IndexedDB is unavailable or blocked, for example in some private-browsing modes or restrictive browser storage policies, DPoP key persistence fails and the DPoP-enabled authentication or token request cannot complete. Disable DPoP or use a browser/storage policy that allows IndexedDB.
+
+## Call a DPoP protected resource
+
+Use `getDpopHeaders()` to create the `Authorization` and `DPoP` headers for your API request.
+
+```typescript
+const accessToken = await idaas.getAccessToken({
+  audience: "https://api.example.com",
+  scope: "accounts:read",
+  dpop: { alg: "ES256" }
+});
+
+if (!accessToken) {
+  throw new Error("No access token available");
+}
+
+const headers = await idaas.getDpopHeaders({
+  method: "GET",
+  uri: "https://api.example.com/accounts",
+  accessToken
+});
+
+const response = await fetch("https://api.example.com/accounts", {
+  method: "GET",
+  headers
+});
+```
+
+The returned headers have this shape:
+
+```typescript
+{
+  Authorization: "DPoP <access-token>",
+  DPoP: "<signed-proof-jwt>"
+}
+```
+
+`getDpopHeaders()` is DPoP-specific. It does not fall back to Bearer headers. It throws when the selected token is not DPoP-bound, when key material cannot be restored, or when the protected resource URI is not absolute `http` or `https`.
+
+## What the protected resource must verify
+
+The SDK only creates the client-side request headers. Your API, gateway, or resource server must validate the token and proof before serving the request.
+
+At minimum, the protected resource must verify:
+
+- The access token signature, issuer, audience, expiry, scopes, and claims.
+- The request uses `Authorization: DPoP <access-token>`.
+- The `DPoP` proof JWT signature is valid with the public JWK in the proof header.
+- The proof header has `typ: "dpop+jwt"`.
+- The `htm` claim matches the HTTP method.
+- The `htu` claim matches the request URI after removing query and fragment.
+- The `iat` value is recent and the proof has not expired.
+- The `jti` value has not already been used for that key.
+- The `ath` claim matches the SHA-256 hash of the access token.
+- The access token confirmation claim `cnf.jkt` matches the JWK thumbprint of the DPoP proof public key.
+
+That final `cnf.jkt` comparison is what proves the caller has both the access token and the private key bound to it.
+
+## Security notes
+
+- DPoP does not replace normal access-token validation. It adds proof-of-possession checks on top of it.
+- DPoP does not make XSS harmless. If attacker-controlled JavaScript runs in your page, it may be able to call SDK methods while the session is active.
+- Do not expose private key material or raw DPoP signing primitives to application code.
+- Use Content Security Policy and standard SPA hardening to reduce script injection risk.
+- Use `https` for protected resources in production.

--- a/docs/guides/security-best-practices.md
+++ b/docs/guides/security-best-practices.md
@@ -9,6 +9,7 @@ This guide covers security considerations specific to using the IDaaS Auth JavaS
 - [What the SDK Protects Against](#what-the-sdk-protects-against)
 - [Token Storage Security](#token-storage-security)
 - [SDK Configuration Security](#sdk-configuration-security)
+- [DPoP Protected Resources](#dpop-protected-resources)
 - [Secure Credential Handling](#secure-credential-handling)
 - [Authentication Method Security](#authentication-method-security)
 - [Security Checklist](#security-checklist)
@@ -141,6 +142,38 @@ const client = new IdaasClient({...}, {
 - Enable refresh token rotation (SDK handles automatically)
 - Implement logout that revokes tokens server-side
 - Consider shorter refresh token lifetime for high-security apps
+
+## DPoP Protected Resources
+
+DPoP binds an access token to browser-held key material. This reduces replay risk if an access token is copied out of the browser, because the token must be presented with a fresh signed proof from the matching private key.
+
+```typescript
+const accessToken = await client.getAccessToken({
+  audience: "https://api.yourapp.com",
+  scope: "accounts:read",
+  dpop: { alg: "ES256" }
+});
+
+if (!accessToken) {
+  throw new Error("No access token available");
+}
+
+const headers = await client.getDpopHeaders({
+  method: "GET",
+  uri: "https://api.yourapp.com/accounts",
+  accessToken
+});
+```
+
+Security considerations:
+
+- `getDpopHeaders()` creates client-side request headers only. Your protected resource must validate the access token and DPoP proof.
+- The resource server must compare the access token `cnf.jkt` claim to the thumbprint of the DPoP proof public key.
+- The SDK keeps private key material non-extractable and does not expose low-level DPoP signing primitives.
+- DPoP does not make XSS harmless. Attacker-controlled JavaScript may still call SDK methods while a session is active.
+- Use `https` for protected resource requests in production.
+
+See [DPoP Protected Resource Requests](./dpop.md) for the full usage and verification checklist.
 
 ## Authentication Method Security
 
@@ -339,6 +372,7 @@ await client.auth.password(userId, password);
 ### SDK Documentation
 
 - [JWT IDaaS Grant Type Security](./jwt-idaas-grant.md#security-considerations) - Detailed security for in-app auth
+- [DPoP Protected Resource Requests](./dpop.md) - DPoP usage and resource server verification requirements
 - [OIDC Guide](./oidc.md) - Hosted authentication flow
 - [RBA Guide](./rba.md) - Self-hosted authentication
 - [Troubleshooting](../troubleshooting.md)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -110,5 +110,6 @@ await idaas.oidc.logout({
 
 - Explore the [OIDC Guide](guides/oidc.md) for more information on the OIDC methods.
 - Visit the [Risk-Based Authentication Guide](guides/rba.md) for advanced flows.
+- Use the [DPoP Guide](guides/dpop.md) when calling DPoP protected resources.
 - See the [Convenience](guides/auth.md) one off authentication methods.
 - Browse the [API Reference](api/README.md) for complete method signatures.

--- a/happydom.ts
+++ b/happydom.ts
@@ -1,3 +1,5 @@
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 
+process.env.IDAAS_AUTH_JS_ALLOW_MEMORY_DPOP_KEY_STORE = "true";
+
 GlobalRegistrator.register();

--- a/src/AuthenticationTransaction.ts
+++ b/src/AuthenticationTransaction.ts
@@ -7,6 +7,7 @@ import {
   requestToken,
   submitAuthChallenge,
 } from "./api";
+import type { IdaasContext } from "./IdaasContext";
 import type {
   AuthenticationRequestParams,
   AuthenticationResponse,
@@ -39,6 +40,8 @@ interface AuthenticationDetails {
   audience?: string;
   maxAge?: number;
   acr?: string;
+  dpopBound?: boolean;
+  dpopKeyRef?: string;
 }
 
 interface RequiredDetails {
@@ -50,6 +53,7 @@ interface RequiredDetails {
 export class AuthenticationTransaction {
   readonly #authenticationRequestParams?: AuthenticationRequestParams;
   readonly #clientId: string;
+  readonly #context: IdaasContext;
   readonly #issuerOrigin: string;
   readonly #oidcConfig: OidcConfig;
   readonly #tokenOptions: TokenOptions;
@@ -65,9 +69,16 @@ export class AuthenticationTransaction {
   #token?: string;
   #abortController?: AbortController;
 
-  constructor({ oidcConfig, tokenOptions, clientId, authenticationRequestParams }: AuthenticationTransactionOptions) {
+  constructor({
+    context,
+    oidcConfig,
+    tokenOptions,
+    clientId,
+    authenticationRequestParams,
+  }: AuthenticationTransactionOptions) {
     const { issuer } = oidcConfig;
 
+    this.#context = context;
     this.#authenticationDetails = {
       scope: tokenOptions.scope,
     };
@@ -83,10 +94,12 @@ export class AuthenticationTransaction {
    */
   public async requestAuthChallenge(): Promise<AuthenticationResponse> {
     // 1. Generate /authorizejwt URL and fetch OIDC details
+    const dpopJkt = await this.#context.getDpopJkt(this.#tokenOptions.dpop);
     const { url, codeVerifier, nonce } = await generateAuthorizationUrl(this.#oidcConfig, {
       clientId: this.#clientId,
       tokenOptions: this.#tokenOptions,
       type: "jwt",
+      dpopJkt,
     });
 
     this.#authenticationDetails.nonce = nonce;
@@ -323,10 +336,14 @@ export class AuthenticationTransaction {
       jwt: this.#token,
     };
 
-    const { id_token, access_token, expires_in, refresh_token } = await requestToken(
-      this.#oidcConfig.token_endpoint,
-      requestBody,
-    );
+    const dpopJwt = await this.#context.createDpopProof({
+      method: "POST",
+      uri: this.#oidcConfig.token_endpoint,
+      dpopOptions: this.#tokenOptions.dpop,
+    });
+
+    const tokenResponse = await requestToken(this.#oidcConfig.token_endpoint, requestBody, dpopJwt);
+    const { id_token, access_token, expires_in, refresh_token } = tokenResponse;
 
     // If includeOpenidScope is false, do not require id_token
     const requireIdToken = this.#tokenOptions.includeOpenidScope !== false;
@@ -338,6 +355,17 @@ export class AuthenticationTransaction {
       throw new Error("failed to fetch refresh token from IDaaS");
     }
 
+    const dpopBound = tokenResponse.token_type.toLowerCase() === "dpop";
+    let dpopKeyRef: string | undefined;
+    if (dpopBound) {
+      const effectiveDpop = this.#context.getEffectiveDpopOptions(this.#tokenOptions.dpop);
+      if (!effectiveDpop) {
+        throw new Error("DPoP-bound token response received without DPoP key material");
+      }
+
+      dpopKeyRef = await this.#context.persistCurrentDpopKeyMaterialForAlg(effectiveDpop.alg);
+    }
+
     this.#authenticationDetails = {
       ...this.#authenticationDetails,
       idToken: id_token as string | undefined,
@@ -347,6 +375,8 @@ export class AuthenticationTransaction {
       audience: this.#tokenOptions.audience,
       maxAge: this.#tokenOptions.maxAge,
       acr: this.#tokenOptions.acrValues,
+      dpopBound,
+      dpopKeyRef,
     };
   };
 

--- a/src/IdaasClient.ts
+++ b/src/IdaasClient.ts
@@ -2,10 +2,11 @@ import type { JWTPayload } from "jose";
 import { AuthClient } from "./AuthClient";
 import { getUserInfo, type RefreshTokenRequest, requestToken, type TokenResponse } from "./api";
 import { IdaasContext, type NormalizedTokenOptions } from "./IdaasContext";
-import type { IdaasClientOptions, TokenOptions, UserClaims } from "./models";
+import type { DpopHeadersOptions, IdaasClientOptions, TokenOptions, UserClaims } from "./models";
 import { OidcClient } from "./OidcClient";
 import { RbaClient } from "./RbaClient";
 import { type AccessToken, StorageManager } from "./storage/StorageManager";
+import { cleanupPersistedDpopKeyMaterialBestEffort } from "./utils/dpopCleanup";
 import { calculateEpochExpiry } from "./utils/format";
 import { readAccessToken, validateUserInfoToken } from "./utils/jwt";
 import { parseStepUpChallenge } from "./utils/wwwAuthenticate";
@@ -52,6 +53,12 @@ export class IdaasClient {
       maxAge: tokenOptions.maxAge,
       acrValues: tokenOptions.acrValues ?? "",
       includeOpenidScope: tokenOptions.includeOpenidScope ?? true,
+      dpop: tokenOptions.dpop
+        ? {
+            alg: tokenOptions.dpop.alg,
+            includeJkt: tokenOptions.dpop.includeJkt ?? false,
+          }
+        : undefined,
     };
 
     this.#context = new IdaasContext({
@@ -185,9 +192,16 @@ export class IdaasClient {
     audience = this.#context.tokenOptions.audience,
     scope = this.#context.tokenOptions.scope,
     acrValues = "",
+    dpop,
   }: TokenOptions = {}): Promise<string | null> {
-    // 1. Remove tokens that are no longer valid
-    this.#storageManager.removeExpiredTokens();
+    const effectiveDpopOptions = this.#context.getEffectiveDpopOptions(dpop);
+
+    // 1. Remove tokens that are no longer valid and clean up orphaned DPoP keys
+    const orphanedDpopKeyRefs = this.#storageManager.removeExpiredTokens();
+    for (const dpopKeyRef of orphanedDpopKeyRefs) {
+      await cleanupPersistedDpopKeyMaterialBestEffort(dpopKeyRef);
+    }
+
     let accessTokens = this.#storageManager.getAccessTokens();
     const requestedScopes = scope.split(" ");
     const now = Date.now();
@@ -202,6 +216,7 @@ export class IdaasClient {
         const tokenScopes = token.scope.split(" ");
         return requestedScopes.every((scope: string) => tokenScopes.includes(scope));
       });
+      accessTokens = accessTokens.filter((token) => (token.dpopBound === true) === !!effectiveDpopOptions);
 
       if (acrValues.trim().length > 0) {
         const requestedAcrValues = acrValues.split(" ").filter(Boolean);
@@ -236,16 +251,46 @@ export class IdaasClient {
           throw new Error("Token that is not valid was not removed");
         }
 
+        let refreshDpopKeyRef: string | undefined;
+        if (requestedToken.dpopBound) {
+          if (!requestedToken.dpopKeyRef) {
+            throw new Error("DPoP-bound token refresh requires stored DPoP key material reference.");
+          }
+          refreshDpopKeyRef = requestedToken.dpopKeyRef;
+        }
+
         const {
           refresh_token: newRefreshToken,
           access_token: newEncodedAccessToken,
           expires_in,
-        } = await this.#requestTokenUsingRefreshToken(refreshToken);
+          token_type,
+        } = await this.#requestTokenUsingRefreshToken(
+          refreshToken,
+          {
+            dpop: requestedToken.dpopBound ? undefined : effectiveDpopOptions,
+          },
+          refreshDpopKeyRef,
+        );
+
+        const newDpopBound = token_type.toLowerCase() === "dpop";
+        let newDpopKeyRef: string | undefined;
+        if (newDpopBound) {
+          newDpopKeyRef = requestedToken.dpopKeyRef;
+
+          if (!newDpopKeyRef) {
+            const effectiveDpopOptions = this.#context.getEffectiveDpopOptions(dpop);
+            if (!effectiveDpopOptions) {
+              throw new Error("DPoP-bound token response received without DPoP key material");
+            }
+
+            newDpopKeyRef = await this.#context.persistCurrentDpopKeyMaterialForAlg(effectiveDpopOptions.alg);
+          }
+        }
 
         const authTime = readAccessToken(newEncodedAccessToken)?.auth_time;
         const newExpiration = calculateEpochExpiry(expires_in, authTime);
 
-        // the refreshed access token to be stored, maintaining expired token's scope and audience
+        // the refreshed access token to be stored, maintaining expired token's scope, audience, and DPoP binding
         const newAccessToken: AccessToken = {
           accessToken: newEncodedAccessToken,
           refreshToken: newRefreshToken,
@@ -253,9 +298,15 @@ export class IdaasClient {
           audience,
           scope,
           acr,
+          dpopBound: newDpopBound,
+          dpopKeyRef: newDpopKeyRef,
         };
 
-        this.#storageManager.removeAccessToken(requestedToken);
+        const orphanedDpopKeyRef = this.#storageManager.removeAccessToken(requestedToken);
+        if (orphanedDpopKeyRef && orphanedDpopKeyRef !== newDpopKeyRef) {
+          await cleanupPersistedDpopKeyMaterialBestEffort(orphanedDpopKeyRef);
+        }
+
         this.#storageManager.saveAccessToken(newAccessToken);
         return newEncodedAccessToken;
       }
@@ -275,16 +326,55 @@ export class IdaasClient {
    * audience will be used if available.
    * @returns User claims from the OpenID Provider, or `null` if unavailable
    */
-  public async getUserInfo(accessToken?: string): Promise<UserClaims | null> {
+  public async getUserInfo(accessToken?: string, tokenOptions: TokenOptions = {}): Promise<UserClaims | null> {
     const { userinfo_endpoint, issuer, jwks_uri } = await this.#context.getConfig();
 
-    const userInfoAccessToken = accessToken ?? (await this.getAccessToken({}));
+    const userInfoAccessToken = accessToken ?? (await this.getAccessToken(tokenOptions));
 
     if (!userInfoAccessToken) {
       throw new Error("Client is not authorized to access the UserInfo endpoint");
     }
 
-    const userInfo = await getUserInfo(userinfo_endpoint, userInfoAccessToken);
+    const matchedStoredToken = this.#storageManager
+      .getAccessTokens()
+      .find((storedToken) => storedToken.accessToken === userInfoAccessToken);
+    const effectiveDpopOptions = tokenOptions.dpop ?? this.#context.tokenOptions.dpop;
+
+    // Determine if DPoP should be used:
+    // 1. If token is in storage and is DPoP-bound, use DPoP if configured
+    // 2. If token is external (not in storage) and tokenOptions.dpop is explicitly provided, treat as opt-in to DPoP
+    const isDpopBound = matchedStoredToken?.dpopBound === true;
+    const isExternalTokenWithExplicitDpop = !matchedStoredToken && !!tokenOptions.dpop;
+    const shouldUseDpop = isDpopBound || (isExternalTokenWithExplicitDpop && !!effectiveDpopOptions);
+
+    if (isDpopBound && !matchedStoredToken?.dpopKeyRef) {
+      throw new Error("DPoP-bound UserInfo request requires stored DPoP key material reference.");
+    }
+
+    let dpopJwt: string | undefined;
+    if (isDpopBound && matchedStoredToken?.dpopKeyRef) {
+      try {
+        dpopJwt = await this.#context.createDpopProofForKeyRef({
+          method: "GET",
+          uri: userinfo_endpoint,
+          dpopKeyRef: matchedStoredToken.dpopKeyRef,
+          accessToken: userInfoAccessToken,
+        });
+      } catch (error) {
+        throw new Error(
+          `Failed to restore DPoP key material for UserInfo request: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    } else if (shouldUseDpop) {
+      dpopJwt = await this.#context.createDpopProof({
+        method: "GET",
+        uri: userinfo_endpoint,
+        accessToken: userInfoAccessToken,
+        dpopOptions: effectiveDpopOptions,
+      });
+    }
+
+    const userInfo = await getUserInfo(userinfo_endpoint, userInfoAccessToken, dpopJwt);
 
     let claims: UserClaims | null;
 
@@ -308,6 +398,73 @@ export class IdaasClient {
     }
 
     return claims;
+  }
+
+  /**
+   * Creates DPoP Authorization headers for a protected resource request.
+   *
+   * This returns both `Authorization: DPoP ...` and a signed `DPoP` proof header using
+   * the key material associated with the selected DPoP-bound access token.
+   *
+   * @param options Protected resource request details and optional token lookup options
+   * @returns DPoP headers to include with the protected resource request
+   */
+  public async getDpopHeaders({
+    method,
+    uri,
+    accessToken,
+    tokenOptions = {},
+  }: DpopHeadersOptions): Promise<Record<string, string>> {
+    let protectedResourceUrl: URL;
+    try {
+      protectedResourceUrl = new URL(uri);
+    } catch {
+      throw new Error("Protected resource URI must be a valid absolute URL.");
+    }
+
+    if (protectedResourceUrl.protocol !== "http:" && protectedResourceUrl.protocol !== "https:") {
+      throw new Error("Protected resource URI must use http or https.");
+    }
+
+    const selectedAccessToken = accessToken ?? (await this.getAccessToken(tokenOptions));
+    if (!selectedAccessToken) {
+      throw new Error("Client is not authorized to access the protected resource");
+    }
+
+    const matchedStoredToken = this.#storageManager
+      .getAccessTokens()
+      .find((storedToken) => storedToken.accessToken === selectedAccessToken);
+
+    if (!matchedStoredToken?.dpopBound) {
+      throw new Error("Selected access token is not DPoP-bound.");
+    }
+
+    if (!matchedStoredToken.dpopKeyRef) {
+      throw new Error("DPoP-bound protected resource request requires stored DPoP key material reference.");
+    }
+
+    let dpopJwt: string;
+    try {
+      dpopJwt = await this.#context.createDpopProofForKeyRef({
+        method,
+        uri: protectedResourceUrl.href,
+        accessToken: selectedAccessToken,
+        dpopKeyRef: matchedStoredToken.dpopKeyRef,
+      });
+    } catch (error) {
+      throw new Error(
+        `Failed to restore DPoP key material for protected resource request: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    if (!dpopJwt) {
+      throw new Error("Failed to create DPoP proof for protected resource request.");
+    }
+
+    return {
+      Authorization: `DPoP ${selectedAccessToken}`,
+      DPoP: dpopJwt,
+    };
   }
 
   /**
@@ -336,7 +493,11 @@ export class IdaasClient {
   }
 
   // Service methods for OidcClient and RbaClient
-  async #requestTokenUsingRefreshToken(refreshToken: string): Promise<TokenResponse> {
+  async #requestTokenUsingRefreshToken(
+    refreshToken: string,
+    tokenOptions: TokenOptions = {},
+    dpopKeyRef?: string,
+  ): Promise<TokenResponse> {
     const { token_endpoint } = await this.#context.getConfig();
 
     const tokenRequest: RefreshTokenRequest = {
@@ -345,6 +506,27 @@ export class IdaasClient {
       refresh_token: refreshToken,
     };
 
-    return await requestToken(token_endpoint, tokenRequest);
+    let dpopJwt: string | undefined;
+    if (dpopKeyRef) {
+      try {
+        dpopJwt = await this.#context.createDpopProofForKeyRef({
+          method: "POST",
+          uri: token_endpoint,
+          dpopKeyRef,
+        });
+      } catch (error) {
+        throw new Error(
+          `Failed to restore DPoP key material for token refresh: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    } else {
+      dpopJwt = await this.#context.createDpopProof({
+        method: "POST",
+        uri: token_endpoint,
+        dpopOptions: tokenOptions.dpop,
+      });
+    }
+
+    return await requestToken(token_endpoint, tokenRequest, dpopJwt);
   }
 }

--- a/src/IdaasContext.ts
+++ b/src/IdaasContext.ts
@@ -1,12 +1,22 @@
 import { fetchOpenidConfiguration, type OidcConfig } from "./api";
 import type { TokenOptions } from "./models";
+import { type DPoPAlg, type DPoPKeyMaterial, generateDpopKeyMaterial, generateDpopProofJwt } from "./utils/dpop";
+import { cleanupPersistedDpopKeyMaterialBestEffort } from "./utils/dpopCleanup";
+import { persistDpopKeyMaterial, retrievePersistedDpopKeyMaterial } from "./utils/dpopKeyStore";
+
+export interface NormalizedDpopOptions {
+  alg: DPoPAlg;
+  includeJkt: boolean;
+}
 
 /**
  * Normalized token options with defaults applied.
  * All properties except audience & maxAge are required.
  */
-export type NormalizedTokenOptions = Required<Omit<TokenOptions, "audience" | "maxAge">> &
-  Pick<TokenOptions, "audience" | "maxAge">;
+export type NormalizedTokenOptions = Required<Omit<TokenOptions, "audience" | "maxAge" | "dpop">> &
+  Pick<TokenOptions, "audience" | "maxAge" | "dpop"> & {
+    dpop?: NormalizedDpopOptions;
+  };
 
 /**
  * Services class to provide shared functionality to OIDC and RBA clients
@@ -19,6 +29,7 @@ export class IdaasContext {
   readonly #allowedIdTokenSigningAlgorithms?: string[];
 
   #config?: OidcConfig;
+  readonly #dpopKeyMaterialByAlg = new Map<DPoPAlg, DPoPKeyMaterial>();
 
   constructor({
     issuerUrl,
@@ -51,6 +62,144 @@ export class IdaasContext {
 
   get allowedIdTokenSigningAlgorithms() {
     return this.#allowedIdTokenSigningAlgorithms;
+  }
+
+  public getEffectiveDpopOptions(dpopOptions?: TokenOptions["dpop"]): NormalizedDpopOptions | undefined {
+    if (!dpopOptions) {
+      return this.#tokenOptions.dpop;
+    }
+
+    return {
+      alg: dpopOptions.alg,
+      includeJkt: dpopOptions.includeJkt ?? this.#tokenOptions.dpop?.includeJkt ?? false,
+    };
+  }
+
+  public async getDpopJkt(dpopOptions?: TokenOptions["dpop"]): Promise<string | undefined> {
+    const effectiveDpop = this.getEffectiveDpopOptions(dpopOptions);
+
+    if (!effectiveDpop?.includeJkt) {
+      return undefined;
+    }
+
+    const keyMaterial = await this.#getDpopKeyMaterial(effectiveDpop.alg);
+    return keyMaterial.jkt;
+  }
+
+  public async createDpopProof({
+    method,
+    uri,
+    dpopOptions,
+    accessToken,
+  }: {
+    method: string;
+    uri: string;
+    dpopOptions?: TokenOptions["dpop"];
+    accessToken?: string;
+  }): Promise<string | undefined> {
+    const effectiveDpop = this.getEffectiveDpopOptions(dpopOptions);
+
+    if (!effectiveDpop) {
+      return undefined;
+    }
+
+    const keyMaterial = await this.#getDpopKeyMaterial(effectiveDpop.alg);
+
+    return await generateDpopProofJwt({
+      alg: effectiveDpop.alg,
+      privateKey: keyMaterial.privateKey,
+      publicJwk: keyMaterial.publicJwk,
+      htm: method,
+      htu: uri,
+      accessToken,
+    });
+  }
+
+  public async createDpopProofForKeyRef({
+    method,
+    uri,
+    dpopKeyRef,
+    accessToken,
+  }: {
+    method: string;
+    uri: string;
+    dpopKeyRef: string;
+    accessToken?: string;
+  }): Promise<string> {
+    const keyMaterial = await retrievePersistedDpopKeyMaterial(dpopKeyRef);
+    if (!keyMaterial) {
+      throw new Error("Unable to restore DPoP key material");
+    }
+
+    return await generateDpopProofJwt({
+      alg: keyMaterial.alg,
+      privateKey: keyMaterial.privateKey,
+      publicJwk: keyMaterial.publicJwk,
+      htm: method,
+      htu: uri,
+      accessToken,
+    });
+  }
+
+  public async persistDpopKeyMaterialForAlg(alg: DPoPAlg): Promise<string> {
+    const keyMaterial = await this.#getDpopKeyMaterial(alg);
+
+    return await persistDpopKeyMaterial({
+      alg,
+      privateKey: keyMaterial.privateKey,
+      publicJwk: keyMaterial.publicJwk,
+      jkt: keyMaterial.jkt,
+    });
+  }
+
+  public async persistCurrentDpopKeyMaterialForAlg(alg: DPoPAlg): Promise<string> {
+    const keyMaterial = this.#dpopKeyMaterialByAlg.get(alg);
+    if (!keyMaterial) {
+      throw new Error("DPoP-bound token response received before DPoP key material was created");
+    }
+
+    return await persistDpopKeyMaterial({
+      alg,
+      privateKey: keyMaterial.privateKey,
+      publicJwk: keyMaterial.publicJwk,
+      jkt: keyMaterial.jkt,
+    });
+  }
+
+  public async restoreDpopKeyMaterialByRef(dpopKeyRef: string): Promise<DPoPAlg> {
+    const restored = await retrievePersistedDpopKeyMaterial(dpopKeyRef);
+    if (!restored) {
+      throw new Error("Unable to restore DPoP key material");
+    }
+
+    this.#dpopKeyMaterialByAlg.set(restored.alg, {
+      privateKey: restored.privateKey,
+      publicJwk: restored.publicJwk,
+      jkt: restored.jkt,
+    });
+
+    return restored.alg;
+  }
+
+  public async clearDpopKeyMaterial(dpopKeyRef?: string): Promise<void> {
+    this.#dpopKeyMaterialByAlg.clear();
+    await cleanupPersistedDpopKeyMaterialBestEffort(dpopKeyRef);
+  }
+
+  public setDpopKeyMaterial(alg: DPoPAlg, keyMaterial: DPoPKeyMaterial): void {
+    this.#dpopKeyMaterialByAlg.set(alg, keyMaterial);
+  }
+
+  async #getDpopKeyMaterial(alg: DPoPAlg): Promise<DPoPKeyMaterial> {
+    const cachedKeyMaterial = this.#dpopKeyMaterialByAlg.get(alg);
+    if (cachedKeyMaterial) {
+      return cachedKeyMaterial;
+    }
+
+    const keyMaterial = await generateDpopKeyMaterial(alg);
+    this.#dpopKeyMaterialByAlg.set(alg, keyMaterial);
+
+    return keyMaterial;
   }
 
   /**

--- a/src/OidcClient.ts
+++ b/src/OidcClient.ts
@@ -4,6 +4,7 @@ import type { IdaasContext } from "./IdaasContext";
 import type { AuthorizeResponse, OidcLoginOptions, OidcLogoutOptions, TokenOptions } from "./models";
 import type { AccessToken, StorageManager, TokenParams } from "./storage/StorageManager";
 import { listenToAuthorizePopup, openPopup } from "./utils/browser";
+import { clearStoredDpopKeyMaterialBestEffort } from "./utils/dpopCleanup";
 import { calculateEpochExpiry, formatUrl, sanitizeUri } from "./utils/format";
 import { readAccessToken, validateIdToken } from "./utils/jwt";
 import { generateAuthorizationUrl } from "./utils/url";
@@ -80,6 +81,8 @@ export class OidcClient {
    * @see {@link https://github.com/EntrustCorporation/idaas-auth-js/blob/main/docs/guides/oidc.md OIDC Guide}
    */
   public async logout({ redirectUri }: OidcLogoutOptions = {}): Promise<void> {
+    await clearStoredDpopKeyMaterialBestEffort(this.#context, this.#storageManager);
+
     this.#storageManager.remove();
 
     window.location.href = await this.#generateLogoutUrl(redirectUri);
@@ -123,17 +126,30 @@ export class OidcClient {
       throw new Error("No token params stored, unable to parse");
     }
 
-    const authorizeCode = this.#validateAuthorizeResponse(authorizeResponse, state);
+    try {
+      const authorizeCode = this.#validateAuthorizeResponse(authorizeResponse, state);
 
-    const validatedTokenResponse = await this.#requestAndValidateTokens(
-      authorizeCode,
-      codeVerifier,
-      redirectUri,
-      nonce,
-      tokenParams.requireIdToken ?? true,
-      tokenParams.acrValues?.split(" ").filter(Boolean),
-    );
-    this.#parseAndSaveTokenResponse(validatedTokenResponse, tokenParams);
+      const validatedTokenResponse = await this.#requestAndValidateTokens(
+        authorizeCode,
+        codeVerifier,
+        redirectUri,
+        nonce,
+        tokenParams.requireIdToken ?? true,
+        tokenParams.acrValues?.split(" ").filter(Boolean),
+        tokenParams.dpop,
+        tokenParams.dpopKeyRef,
+      );
+      await this.#parseAndSaveTokenResponse(validatedTokenResponse, tokenParams);
+    } catch (error) {
+      // On error, clean up any restored DPoP key material to prevent orphaned keys in IndexedDB
+      if (tokenParams.dpopKeyRef) {
+        await this.#context.clearDpopKeyMaterial(tokenParams.dpopKeyRef);
+      }
+      throw error;
+    } finally {
+      this.#storageManager.removeTokenParams();
+    }
+
     return null;
   }
 
@@ -212,6 +228,8 @@ export class OidcClient {
     nonce: string,
     requireIdToken: boolean,
     requestedAcrValues?: string[],
+    dpopOptions?: TokenOptions["dpop"],
+    dpopKeyRef?: string,
   ) {
     const { token_endpoint, id_token_signing_alg_values_supported, acr_values_supported, jwks_uri } =
       await this.#context.getConfig();
@@ -224,7 +242,19 @@ export class OidcClient {
       redirect_uri: redirectUri,
     };
 
-    const tokenResponse = await requestToken(token_endpoint, tokenRequest);
+    const dpopJwt = dpopKeyRef
+      ? await this.#context.createDpopProofForKeyRef({
+          method: "POST",
+          uri: token_endpoint,
+          dpopKeyRef,
+        })
+      : await this.#context.createDpopProof({
+          method: "POST",
+          uri: token_endpoint,
+          dpopOptions,
+        });
+
+    const tokenResponse = await requestToken(token_endpoint, tokenRequest, dpopJwt);
 
     if (!tokenResponse.id_token && !requireIdToken) {
       return { tokenResponse };
@@ -262,21 +292,38 @@ export class OidcClient {
   /**
    * Parses the token response from the OIDC provider and saves tokens to storage.
    * Extracts access token, ID token, and refresh token (if available).
+   * Preserves the DPoP key reference from tokenParams to enable recovery on page reload and cleanup on logout.
    * @param validatedTokenResponse The validated response from the token endpoint
    */
-  #parseAndSaveTokenResponse(validatedTokenResponse: ValidatedTokenResponse, tokenParams: TokenParams): void {
+  async #parseAndSaveTokenResponse(
+    validatedTokenResponse: ValidatedTokenResponse,
+    tokenParams: TokenParams,
+  ): Promise<void> {
     const { tokenResponse, decodedIdToken, encodedIdToken } = validatedTokenResponse;
     const { refresh_token, access_token, expires_in } = tokenResponse;
     const authTime = readAccessToken(access_token)?.auth_time;
     const expiresAt = calculateEpochExpiry(expires_in, authTime);
 
-    const { audience, scope, maxAge } = tokenParams;
+    const { audience, scope, maxAge, dpop } = tokenParams;
     const maxAgeExpiry = maxAge ? calculateEpochExpiry(maxAge.toString(), authTime) : undefined;
-
-    this.#storageManager.removeTokenParams();
 
     const token = readAccessToken(access_token);
     const acr = token?.acr ?? undefined;
+    const isDpopBound = tokenResponse.token_type.toLowerCase() === "dpop";
+
+    let dpopKeyRef = tokenParams.dpopKeyRef;
+    if (isDpopBound) {
+      if (!dpop?.alg) {
+        throw new Error("DPoP-bound token response received without DPoP key material");
+      }
+
+      if (!dpopKeyRef) {
+        dpopKeyRef = await this.#context.persistCurrentDpopKeyMaterialForAlg(dpop.alg);
+      }
+    } else if (dpopKeyRef) {
+      await this.#context.clearDpopKeyMaterial(dpopKeyRef);
+      dpopKeyRef = undefined;
+    }
 
     const newAccessToken: AccessToken = {
       refreshToken: refresh_token,
@@ -286,6 +333,8 @@ export class OidcClient {
       scope,
       maxAgeExpiry,
       acr,
+      dpopBound: isDpopBound,
+      dpopKeyRef,
     };
 
     if (encodedIdToken && decodedIdToken) {
@@ -303,6 +352,7 @@ export class OidcClient {
    */
   async #loginWithPopup({ redirectUri }: OidcLoginOptions, tokenOptions: TokenOptions): Promise<string | null> {
     const finalRedirectUri = redirectUri ?? sanitizeUri(window.location.href);
+    const dpopJkt = await this.#context.getDpopJkt(tokenOptions.dpop);
 
     const { url, nonce, state, codeVerifier, usedScope } = await generateAuthorizationUrl(
       await this.#context.getConfig(),
@@ -311,6 +361,7 @@ export class OidcClient {
         clientId: this.#context.clientId,
         responseMode: "web_message",
         redirectUri: finalRedirectUri,
+        dpopJkt,
         tokenOptions: {
           ...this.#context.tokenOptions,
           ...tokenOptions,
@@ -323,6 +374,7 @@ export class OidcClient {
       scope: usedScope,
       requireIdToken: (tokenOptions.includeOpenidScope ?? this.#context.tokenOptions.includeOpenidScope) !== false,
       acrValues: tokenOptions.acrValues ?? this.#context.tokenOptions.acrValues,
+      dpop: this.#context.getEffectiveDpopOptions(tokenOptions.dpop),
     };
 
     if (tokenOptions.maxAge !== undefined && tokenOptions.maxAge >= 0) {
@@ -341,9 +393,10 @@ export class OidcClient {
       nonce,
       tokenParams.requireIdToken ?? true,
       tokenParams.acrValues?.split(" ").filter(Boolean),
+      tokenParams.dpop,
     );
 
-    this.#parseAndSaveTokenResponse(validatedTokenResponse, tokenParams);
+    await this.#parseAndSaveTokenResponse(validatedTokenResponse, tokenParams);
 
     // redirect only if the redirectUri is not the current uri
     if (formatUrl(window.location.href) !== formatUrl(finalRedirectUri)) {
@@ -359,6 +412,15 @@ export class OidcClient {
    */
   async #loginWithRedirect({ redirectUri }: OidcLoginOptions, tokenOptions: TokenOptions): Promise<void> {
     const finalRedirectUri = redirectUri ?? sanitizeUri(window.location.href);
+    await this.#clearAbandonedRedirectDpopKeyMaterial();
+
+    const effectiveDpop = this.#context.getEffectiveDpopOptions(tokenOptions.dpop);
+    const dpopJkt = await this.#context.getDpopJkt(tokenOptions.dpop);
+
+    const dpopKeyRef = effectiveDpop?.includeJkt
+      ? await this.#context.persistDpopKeyMaterialForAlg(effectiveDpop.alg)
+      : undefined;
+
     const { url, nonce, state, codeVerifier, usedScope } = await generateAuthorizationUrl(
       await this.#context.getConfig(),
       {
@@ -366,6 +428,7 @@ export class OidcClient {
         clientId: this.#context.clientId,
         responseMode: "query",
         redirectUri: finalRedirectUri,
+        dpopJkt,
         tokenOptions: {
           ...this.#context.tokenOptions,
           ...tokenOptions,
@@ -378,6 +441,8 @@ export class OidcClient {
       scope: usedScope,
       requireIdToken: (tokenOptions.includeOpenidScope ?? this.#context.tokenOptions.includeOpenidScope) !== false,
       acrValues: tokenOptions.acrValues ?? this.#context.tokenOptions.acrValues,
+      dpop: this.#context.getEffectiveDpopOptions(tokenOptions.dpop),
+      dpopKeyRef,
     };
 
     if (tokenOptions.maxAge !== undefined && tokenOptions.maxAge >= 0) {
@@ -394,5 +459,12 @@ export class OidcClient {
     });
 
     window.location.href = url;
+  }
+
+  async #clearAbandonedRedirectDpopKeyMaterial(): Promise<void> {
+    const existingTokenParams = this.#storageManager.getTokenParams();
+    if (existingTokenParams?.dpopKeyRef) {
+      await this.#context.clearDpopKeyMaterial(existingTokenParams.dpopKeyRef);
+    }
   }
 }

--- a/src/RbaClient.ts
+++ b/src/RbaClient.ts
@@ -9,6 +9,7 @@ import type {
   TokenOptions,
 } from "./models";
 import type { StorageManager } from "./storage/StorageManager";
+import { clearStoredDpopKeyMaterialBestEffort } from "./utils/dpopCleanup";
 import { calculateEpochExpiry } from "./utils/format";
 import { validateIdToken } from "./utils/jwt";
 
@@ -130,14 +131,18 @@ export class RbaClient {
    * @see {@link https://github.com/EntrustCorporation/idaas-auth-js/blob/main/docs/guides/rba.md RBA Guide}
    */
   public async logout(): Promise<void> {
+    await clearStoredDpopKeyMaterialBestEffort(this.#context, this.#storageManager);
+
     const baseUrl = new URL(this.#context.issuerUrl).origin;
     const token = this.#storageManager.getIdaasSessionToken()?.token;
 
-    if (token) {
-      await logoutSilently(token, baseUrl);
+    try {
+      if (token) {
+        await logoutSilently(token, baseUrl);
+      }
+    } finally {
+      this.#storageManager.remove();
     }
-
-    this.#storageManager.remove();
   }
 
   /**
@@ -211,6 +216,7 @@ export class RbaClient {
     }
 
     this.#authenticationTransaction = new AuthenticationTransaction({
+      context: this.#context,
       oidcConfig,
       authenticationRequestParams,
       tokenOptions: {
@@ -220,6 +226,7 @@ export class RbaClient {
         useRefreshToken: tokenOptions?.useRefreshToken ?? this.#context.tokenOptions.useRefreshToken,
         maxAge: tokenOptions?.maxAge ?? this.#context.tokenOptions.maxAge,
         includeOpenidScope: effectiveincludeOpenidScope,
+        dpop: tokenOptions?.dpop ?? this.#context.tokenOptions.dpop,
       },
       clientId: this.#context.clientId,
     });
@@ -230,8 +237,19 @@ export class RbaClient {
       throw new Error("No authentication transaction in progress!");
     }
 
-    const { idToken, accessToken, refreshToken, scope, expiresAt, maxAge, audience, acr, nonce } =
-      this.#authenticationTransaction.getAuthenticationDetails();
+    const {
+      idToken,
+      accessToken,
+      refreshToken,
+      scope,
+      expiresAt,
+      maxAge,
+      audience,
+      acr,
+      nonce,
+      dpopBound,
+      dpopKeyRef,
+    } = this.#authenticationTransaction.getAuthenticationDetails();
 
     // Only require accessToken for OAuth-only flows
     const requireIdToken = this.#authenticationTransaction.requiresIdToken();
@@ -248,6 +266,8 @@ export class RbaClient {
       audience,
       maxAgeExpiry: maxAge ? calculateEpochExpiry(maxAge.toString()) : undefined,
       acr,
+      dpopBound,
+      dpopKeyRef,
     });
 
     // Save ID token only if present

--- a/src/api.ts
+++ b/src/api.ts
@@ -112,16 +112,23 @@ export const fetchOpenidConfiguration = async (issuerUrl: string): Promise<OidcC
 export const requestToken = async (
   tokenEndpoint: string,
   tokenRequest: AccessTokenRequest | RefreshTokenRequest | JwtIdaasTokenRequest,
+  dpopJwt?: string,
 ): Promise<TokenResponse> => {
   const searchParams = new URLSearchParams({
     ...tokenRequest,
   });
 
+  const headers: Record<string, string> = {
+    "Content-Type": "application/x-www-form-urlencoded",
+  };
+
+  if (dpopJwt) {
+    headers.DPoP = dpopJwt;
+  }
+
   const response = await fetch(tokenEndpoint, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-    },
+    headers,
     body: searchParams,
   });
 
@@ -136,12 +143,19 @@ export const requestToken = async (
  * @return a string representing either a JSON object or a signed jwt containing the user claims, depending on the OIDC
  * application configuration
  */
-export const getUserInfo = async (userInfoEndpoint: string, accessToken: string) => {
+export const getUserInfo = async (userInfoEndpoint: string, accessToken: string, dpopJwt?: string) => {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${accessToken}`,
+  };
+
+  if (dpopJwt) {
+    headers.Authorization = `DPoP ${accessToken}`;
+    headers.DPoP = dpopJwt;
+  }
+
   const response = await fetch(userInfoEndpoint, {
     method: "GET",
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
+    headers,
   });
 
   return await response.text();

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ export type {
   AuthenticationRequestParams,
   AuthenticationResponse,
   AuthenticationSubmissionParams,
+  DPoPOptions,
+  DpopHeadersOptions,
   FaceBiometricOptions,
   IdaasAuthenticationMethod,
   IdaasClientOptions,

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,4 +1,5 @@
 import type { OidcConfig } from "../api";
+import type { IdaasContext } from "../IdaasContext";
 import type {
   FaceChallenge,
   GridChallenge,
@@ -101,6 +102,56 @@ export interface TokenOptions {
    * @default true
    */
   includeOpenidScope?: boolean;
+
+  /**
+   * DPoP (Demonstration of Proof-of-Possession) configuration.
+   *
+   * Omit this field to disable DPoP.
+   * Provide an object to enable DPoP.
+   */
+  dpop?: DPoPOptions;
+}
+
+/**
+ * DPoP (Demonstration of Proof-of-Possession) options.
+ */
+export interface DPoPOptions {
+  /**
+   * Signing algorithm used for DPoP proof JWTs.
+   */
+  alg: "ES256" | "ES384" | "ES512" | "PS256" | "PS384" | "PS512" | "RS256" | "RS384" | "RS512";
+
+  /**
+   * When `true`, includes `dpop_jkt` in authorization requests.
+   *
+   * @default false
+   */
+  includeJkt?: boolean;
+}
+
+/**
+ * Options for creating DPoP Authorization headers for a protected resource request.
+ */
+export interface DpopHeadersOptions {
+  /**
+   * HTTP method that will be used for the protected resource request.
+   */
+  method: string;
+
+  /**
+   * Absolute HTTP or HTTPS URI that will be used for the protected resource request.
+   */
+  uri: string;
+
+  /**
+   * Optional access token to use. If omitted, the SDK retrieves one using `tokenOptions`.
+   */
+  accessToken?: string;
+
+  /**
+   * Token lookup options used when `accessToken` is omitted.
+   */
+  tokenOptions?: TokenOptions;
 }
 
 /**
@@ -168,6 +219,11 @@ export interface UserClaims {
 }
 
 export interface AuthenticationTransactionOptions {
+  /**
+   * Shared IDaaS client context.
+   */
+  context: IdaasContext;
+
   /**
    * The OIDC config of the IDaaSClient.
    */

--- a/src/storage/StorageManager.ts
+++ b/src/storage/StorageManager.ts
@@ -1,4 +1,5 @@
 import type { JWTPayload } from "jose";
+import type { DPoPOptions } from "../models";
 import { LocalStorageStore } from "./LocalStorageStore";
 import { InMemoryStore } from "./MemoryStore";
 import type { IStore } from "./shared";
@@ -27,6 +28,11 @@ export interface TokenParams {
   scope: string;
   requireIdToken?: boolean;
   acrValues?: string;
+  dpop?: {
+    alg: NonNullable<DPoPOptions["alg"]>;
+    includeJkt: boolean;
+  };
+  dpopKeyRef?: string;
 
   // RFC 9470
   maxAge?: number;
@@ -59,6 +65,8 @@ export interface AccessToken {
   scope: string;
   maxAgeExpiry?: number;
   acr?: string;
+  dpopBound?: boolean;
+  dpopKeyRef?: string;
 }
 
 export class StorageManager {
@@ -134,13 +142,6 @@ export class StorageManager {
    */
   public saveAccessToken(data: AccessToken) {
     const accessTokens = this.getAccessTokens();
-
-    if (!accessTokens) {
-      const stringifiedData = JSON.stringify([data]);
-      this.#save(this.#accessTokenStorageKey, stringifiedData);
-      return;
-    }
-
     accessTokens.push(data);
     const stringifiedData = JSON.stringify(accessTokens);
     this.#save(this.#accessTokenStorageKey, stringifiedData);
@@ -149,11 +150,12 @@ export class StorageManager {
   /**
    * Remove an access token from storage.
    * @param removedToken the token to be removed.
+   * @returns The dpopKeyRef that was in the removed token, if it is no longer referenced by any other token.
    */
-  public removeAccessToken(removedToken: AccessToken) {
+  public removeAccessToken(removedToken: AccessToken): string | undefined {
     const accessTokens = this.getAccessTokens();
-    if (!accessTokens || accessTokens.length === 0) {
-      return;
+    if (accessTokens.length === 0) {
+      return undefined;
     }
 
     const index = accessTokens.findIndex((token) => token.accessToken === removedToken.accessToken);
@@ -162,36 +164,54 @@ export class StorageManager {
       throw new Error("error removing access token, token not found");
     }
 
+    const removedDpopKeyRef = accessTokens[index]?.dpopKeyRef;
+
     accessTokens.splice(index, 1);
     const stringifiedData = JSON.stringify(accessTokens);
     this.#save(this.#accessTokenStorageKey, stringifiedData);
+
+    // Check if the removed token's dpopKeyRef is still referenced by any other token
+    if (removedDpopKeyRef && !accessTokens.some((token) => token.dpopKeyRef === removedDpopKeyRef)) {
+      return removedDpopKeyRef;
+    }
+
+    return undefined;
   }
 
   /**
-   * Removes expired token from storage.
+   * Removes expired tokens from storage.
+   * @returns Array of dpopKeyRefs that are no longer referenced by any token and should be cleaned up.
    */
-  public removeExpiredTokens(): void {
+  public removeExpiredTokens(): string[] {
     const tokens = this.getAccessTokens();
-    if (!tokens) {
-      return;
-    }
     const now = Math.floor(Date.now() / 1000);
     // buffer (in seconds) to refresh/delete early, ensures an expired token is not returned
     const buffer = 15;
 
-    for (const token of tokens) {
+    const orphanedDpopKeyRefs: string[] = [];
+
+    for (const token of [...tokens]) {
       if (token.maxAgeExpiry) {
         if (now > token.maxAgeExpiry - buffer) {
-          this.removeAccessToken(token);
+          const orphaned = this.removeAccessToken(token);
+          if (orphaned) {
+            orphanedDpopKeyRefs.push(orphaned);
+          }
+          continue;
         }
       }
 
       if (now > token.expiresAt - buffer) {
         if (!token.refreshToken) {
-          this.removeAccessToken(token);
+          const orphaned = this.removeAccessToken(token);
+          if (orphaned) {
+            orphanedDpopKeyRefs.push(orphaned);
+          }
         }
       }
     }
+
+    return orphanedDpopKeyRefs;
   }
 
   /**
@@ -262,6 +282,7 @@ export class StorageManager {
     this.#storage.delete(this.#clientParamsStorageKey);
     this.#storage.delete(this.#accessTokenStorageKey);
     this.#storage.delete(this.#idTokenStorageKey);
+    this.#storage.delete(this.#idaasSessionTokenStorageKey);
     this.#storage.delete(this.#tokenParamsStorageKey);
   }
 }

--- a/src/utils/dpop.ts
+++ b/src/utils/dpop.ts
@@ -1,0 +1,128 @@
+import { calculateJwkThumbprint, exportJWK, type JWK, SignJWT } from "jose";
+
+export type DPoPAlg = "ES256" | "ES384" | "ES512" | "PS256" | "PS384" | "PS512" | "RS256" | "RS384" | "RS512";
+
+export interface DPoPKeyMaterial {
+  privateKey: CryptoKey;
+  publicJwk: JWK;
+  jkt: string;
+}
+
+const DPOP_PROOF_LIFETIME_SECONDS = 60;
+
+export const generateDpopKeyMaterial = async (alg: DPoPAlg): Promise<DPoPKeyMaterial> => {
+  const keyPair = await generateKeyPair(alg);
+  const publicJwk = await exportJWK(keyPair.publicKey);
+  const jkt = await calculateJwkThumbprint(publicJwk, "sha256");
+
+  return {
+    privateKey: keyPair.privateKey,
+    publicJwk,
+    jkt,
+  };
+};
+
+export const generateDpopProofJwt = async ({
+  alg,
+  privateKey,
+  publicJwk,
+  htm,
+  htu,
+  accessToken,
+}: {
+  alg: DPoPAlg;
+  privateKey: CryptoKey;
+  publicJwk: JWK;
+  htm: string;
+  htu: string;
+  accessToken?: string;
+}): Promise<string> => {
+  const now = Math.floor(Date.now() / 1000);
+
+  const claims: Record<string, string | number> = {
+    htm: htm.toUpperCase(),
+    htu: normalizeHtu(htu),
+    iat: now,
+    exp: now + DPOP_PROOF_LIFETIME_SECONDS,
+    jti: getJti(),
+  };
+
+  if (accessToken) {
+    claims.ath = await getAth(accessToken);
+  }
+
+  return await new SignJWT(claims)
+    .setProtectedHeader({
+      alg,
+      typ: "dpop+jwt",
+      jwk: publicJwk,
+    })
+    .sign(privateKey);
+};
+
+const generateKeyPair = async (alg: DPoPAlg): Promise<CryptoKeyPair> => {
+  if (alg === "ES256" || alg === "ES384" || alg === "ES512") {
+    const namedCurve = alg === "ES256" ? "P-256" : alg === "ES384" ? "P-384" : "P-521";
+
+    return await window.crypto.subtle.generateKey(
+      {
+        name: "ECDSA",
+        namedCurve,
+      },
+      false,
+      ["sign", "verify"],
+    );
+  }
+
+  if (alg === "PS256" || alg === "PS384" || alg === "PS512") {
+    const hash = alg === "PS256" ? "SHA-256" : alg === "PS384" ? "SHA-384" : "SHA-512";
+
+    return await window.crypto.subtle.generateKey(
+      {
+        name: "RSA-PSS",
+        modulusLength: 2048,
+        publicExponent: new Uint8Array([1, 0, 1]),
+        hash,
+      },
+      false,
+      ["sign", "verify"],
+    );
+  }
+
+  const hash = alg === "RS256" ? "SHA-256" : alg === "RS384" ? "SHA-384" : "SHA-512";
+
+  return await window.crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash,
+    },
+    false,
+    ["sign", "verify"],
+  );
+};
+
+const normalizeHtu = (htu: string): string => {
+  const url = new URL(htu);
+  url.search = "";
+  url.hash = "";
+  return url.href;
+};
+
+const getJti = (): string => {
+  if (typeof window.crypto.randomUUID === "function") {
+    return window.crypto.randomUUID();
+  }
+
+  const randomBytes = window.crypto.getRandomValues(new Uint8Array(16));
+  return Array.from(randomBytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+};
+
+const getAth = async (accessToken: string): Promise<string> => {
+  const encoder = new TextEncoder();
+  const hash = await window.crypto.subtle.digest("SHA-256", encoder.encode(accessToken));
+  const hashBytes = new Uint8Array(hash);
+  const binary = String.fromCharCode(...hashBytes);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+};

--- a/src/utils/dpopCleanup.ts
+++ b/src/utils/dpopCleanup.ts
@@ -1,0 +1,39 @@
+import type { IdaasContext } from "../IdaasContext";
+import type { StorageManager } from "../storage/StorageManager";
+import { cleanupPersistedDpopKeyMaterial } from "./dpopKeyStore";
+
+export const cleanupPersistedDpopKeyMaterialBestEffort = async (dpopKeyRef?: string): Promise<void> => {
+  if (!dpopKeyRef) {
+    return;
+  }
+
+  try {
+    await cleanupPersistedDpopKeyMaterial(dpopKeyRef);
+  } catch {
+    // DPoP key cleanup must not block token retrieval or local session cleanup.
+  }
+};
+
+export const clearStoredDpopKeyMaterialBestEffort = async (
+  context: IdaasContext,
+  storageManager: StorageManager,
+): Promise<void> => {
+  const dpopKeyRefs = new Set<string>();
+
+  for (const token of storageManager.getAccessTokens()) {
+    if (token.dpopKeyRef) {
+      dpopKeyRefs.add(token.dpopKeyRef);
+    }
+  }
+
+  const tokenParams = storageManager.getTokenParams();
+  if (tokenParams?.dpopKeyRef) {
+    dpopKeyRefs.add(tokenParams.dpopKeyRef);
+  }
+
+  for (const dpopKeyRef of dpopKeyRefs) {
+    await context.clearDpopKeyMaterial(dpopKeyRef);
+  }
+
+  await context.clearDpopKeyMaterial();
+};

--- a/src/utils/dpopKeyStore.ts
+++ b/src/utils/dpopKeyStore.ts
@@ -1,0 +1,168 @@
+import type { JWK } from "jose";
+import type { DPoPAlg, DPoPKeyMaterial } from "./dpop";
+
+interface PersistedDpopKeyMaterial {
+  id: string;
+  alg: DPoPAlg;
+  privateKey: CryptoKey;
+  publicJwk: JWK;
+  jkt: string;
+}
+
+const DB_NAME = "idaas-auth-js";
+const STORE_NAME = "dpop-key-material";
+const DB_VERSION = 1;
+const INDEXED_DB_REQUIRED_MESSAGE =
+  "DPoP requires IndexedDB support to persist key material. Disable DPoP or use a browser with IndexedDB.";
+
+const memoryFallbackStore = new Map<string, PersistedDpopKeyMaterial>();
+
+const hasIndexedDb = (): boolean => {
+  return typeof indexedDB !== "undefined";
+};
+
+const allowsTestMemoryStore = (): boolean => {
+  return (
+    typeof process !== "undefined" && process.env.IDAAS_AUTH_JS_ALLOW_MEMORY_DPOP_KEY_STORE?.toLowerCase() === "true"
+  );
+};
+
+const createRandomId = (): string => {
+  if (typeof window.crypto.randomUUID === "function") {
+    return window.crypto.randomUUID();
+  }
+
+  const randomBytes = window.crypto.getRandomValues(new Uint8Array(16));
+  return Array.from(randomBytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+};
+
+const openStore = async (): Promise<IDBDatabase> => {
+  return await new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: "id" });
+      }
+    };
+
+    request.onerror = () => {
+      reject(request.error ?? new Error("Failed to open IndexedDB for DPoP key material"));
+    };
+
+    request.onsuccess = () => {
+      resolve(request.result);
+    };
+  });
+};
+
+const withStore = async <T>(mode: IDBTransactionMode, callback: (store: IDBObjectStore) => Promise<T>): Promise<T> => {
+  const db = await openStore();
+
+  try {
+    const transaction = db.transaction(STORE_NAME, mode);
+    const store = transaction.objectStore(STORE_NAME);
+    const result = await callback(store);
+    await transactionToPromise(transaction);
+    return result;
+  } finally {
+    db.close();
+  }
+};
+
+const transactionToPromise = async (transaction: IDBTransaction): Promise<void> => {
+  return await new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error ?? new Error("IndexedDB transaction failed"));
+    transaction.onabort = () => reject(transaction.error ?? new Error("IndexedDB transaction aborted"));
+  });
+};
+
+const requestToPromise = async <T>(request: IDBRequest<T>): Promise<T> => {
+  return await new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error("IndexedDB request failed"));
+  });
+};
+
+export const persistDpopKeyMaterial = async ({
+  alg,
+  privateKey,
+  publicJwk,
+  jkt,
+}: DPoPKeyMaterial & { alg: DPoPAlg }): Promise<string> => {
+  const id = createRandomId();
+  const record: PersistedDpopKeyMaterial = {
+    id,
+    alg,
+    privateKey,
+    publicJwk,
+    jkt,
+  };
+
+  if (!hasIndexedDb()) {
+    if (!allowsTestMemoryStore()) {
+      throw new Error(INDEXED_DB_REQUIRED_MESSAGE);
+    }
+
+    memoryFallbackStore.set(id, record);
+    return id;
+  }
+
+  try {
+    await withStore("readwrite", async (store) => {
+      await requestToPromise(store.put(record));
+      return undefined;
+    });
+  } catch (error) {
+    throw new Error(INDEXED_DB_REQUIRED_MESSAGE, { cause: error });
+  }
+
+  return id;
+};
+
+export const retrievePersistedDpopKeyMaterial = async (
+  id: string,
+): Promise<(DPoPKeyMaterial & { alg: DPoPAlg }) | undefined> => {
+  if (!hasIndexedDb()) {
+    const record = memoryFallbackStore.get(id);
+    if (!record) {
+      return undefined;
+    }
+
+    return {
+      alg: record.alg,
+      privateKey: record.privateKey,
+      publicJwk: record.publicJwk,
+      jkt: record.jkt,
+    };
+  }
+
+  return await withStore("readonly", async (store) => {
+    const record = await requestToPromise(store.get(id) as IDBRequest<PersistedDpopKeyMaterial | undefined>);
+
+    if (!record) {
+      return undefined;
+    }
+
+    return {
+      alg: record.alg,
+      privateKey: record.privateKey,
+      publicJwk: record.publicJwk,
+      jkt: record.jkt,
+    };
+  });
+};
+
+export const cleanupPersistedDpopKeyMaterial = async (id: string): Promise<void> => {
+  if (!hasIndexedDb()) {
+    memoryFallbackStore.delete(id);
+    return;
+  }
+
+  await withStore("readwrite", async (store) => {
+    await requestToPromise(store.delete(id));
+    return undefined;
+  });
+};

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -11,6 +11,7 @@ export interface GenerateAuthorizationUrlOptions {
   // OIDC flow params
   responseMode?: "query" | "web_message";
   redirectUri?: string;
+  dpopJkt?: string;
 
   // Control parameters
   type: "standard" | "jwt";
@@ -85,6 +86,10 @@ export const generateAuthorizationUrl = async (
   // Add ACR values if provided
   if (options.tokenOptions.acrValues && options.tokenOptions.acrValues.trim().length > 0) {
     url.searchParams.append("acr_values", options.tokenOptions.acrValues);
+  }
+
+  if (options.dpopJkt) {
+    url.searchParams.append("dpop_jkt", options.dpopJkt);
   }
 
   url.searchParams.append("response_type", "code");

--- a/test/unit/IdaasClient/getAccessToken.test.ts
+++ b/test/unit/IdaasClient/getAccessToken.test.ts
@@ -1,5 +1,9 @@
 import { afterAll, afterEach, describe, expect, jest, spyOn, test } from "bun:test";
+import { decodeProtectedHeader } from "jose";
+import { IdaasClient } from "../../../src";
 import type { AccessToken } from "../../../src/storage/StorageManager";
+import { generateDpopKeyMaterial } from "../../../src/utils/dpop";
+import { persistDpopKeyMaterial, retrievePersistedDpopKeyMaterial } from "../../../src/utils/dpopKeyStore";
 import {
   NO_DEFAULT_IDAAS_CLIENT,
   SET_DEFAULTS_IDAAS_CLIENT,
@@ -8,12 +12,15 @@ import {
   TEST_ACCESS_TOKEN_OBJECT,
   TEST_AUDIENCE,
   TEST_BASE_URI,
+  TEST_CLIENT_ID,
   TEST_DIFFERENT_ACCESS_TOKEN,
   TEST_DIFFERENT_AUDIENCE,
   TEST_DIFFERENT_SCOPE,
+  TEST_ISSUER_URI,
   TEST_SCOPE,
+  TEST_TOKEN_RESPONSE,
 } from "../constants";
-import { mockFetch } from "../helpers";
+import { blockIndexedDb, mockFetch } from "../helpers";
 
 describe("IdaasClient.getAccessToken", () => {
   afterAll(() => {
@@ -23,6 +30,8 @@ describe("IdaasClient.getAccessToken", () => {
   afterEach(() => {
     localStorage.clear();
     jest.clearAllMocks();
+    // @ts-expect-error not full type
+    spyOnFetch.mockImplementation(mockFetch);
   });
 
   // @ts-expect-error not full type
@@ -129,6 +138,27 @@ describe("IdaasClient.getAccessToken", () => {
     expect(token).toStrictEqual(TEST_ACCESS_TOKEN);
   });
 
+  test("returns a valid token when cleanup for an expired DPoP token fails", async () => {
+    storeToken({
+      ...TEST_ACCESS_TOKEN_OBJECT,
+      expiresAt: 0,
+      accessToken: "expiredToken",
+      refreshToken: undefined,
+      dpopKeyRef: "expired-dpop-key-ref",
+    });
+    storeToken(TEST_ACCESS_TOKEN_OBJECT);
+
+    const restoreIndexedDb = blockIndexedDb();
+
+    try {
+      const token = await NO_DEFAULT_IDAAS_CLIENT.getAccessToken({ audience: TEST_AUDIENCE });
+
+      expect(token).toStrictEqual(TEST_ACCESS_TOKEN);
+    } finally {
+      restoreIndexedDb();
+    }
+  });
+
   test("refreshes a token with the requested scopes and audience that is expired and refreshable", async () => {
     storeToken({ ...TEST_ACCESS_TOKEN_OBJECT, expiresAt: 0, scope: "1" });
     storeToken({ ...TEST_ACCESS_TOKEN_OBJECT, accessToken: "notRefreshed", scope: "1 2" });
@@ -146,6 +176,110 @@ describe("IdaasClient.getAccessToken", () => {
     const storedTokens = JSON.parse(localStorage.getItem(TEST_ACCESS_PAIR.key) as string);
     expect(storedTokens.length).toBe(2);
     expect(token).toStrictEqual(TEST_ACCESS_TOKEN);
+  });
+
+  test("ignores Bearer tokens when DPoP is enabled", async () => {
+    storeToken(TEST_ACCESS_TOKEN_OBJECT);
+
+    await expect(
+      NO_DEFAULT_IDAAS_CLIENT.getAccessToken({
+        audience: TEST_AUDIENCE,
+        dpop: { alg: "ES256" },
+      }),
+    ).rejects.toThrow("Requested token not found");
+  });
+
+  test("ignores DPoP-bound tokens when DPoP is not enabled", async () => {
+    const keyMaterial = await generateDpopKeyMaterial("ES256");
+    const dpopKeyRef = await persistDpopKeyMaterial({ alg: "ES256", ...keyMaterial });
+    storeToken({ ...TEST_ACCESS_TOKEN_OBJECT, dpopBound: true, dpopKeyRef });
+
+    await expect(NO_DEFAULT_IDAAS_CLIENT.getAccessToken({ audience: TEST_AUDIENCE })).rejects.toThrow(
+      "Requested token not found",
+    );
+  });
+
+  test("returns a DPoP-bound token when DPoP is enabled", async () => {
+    const keyMaterial = await generateDpopKeyMaterial("ES256");
+    const dpopKeyRef = await persistDpopKeyMaterial({ alg: "ES256", ...keyMaterial });
+    storeToken({ ...TEST_ACCESS_TOKEN_OBJECT, accessToken: "bearer-token" });
+    storeToken({ ...TEST_ACCESS_TOKEN_OBJECT, accessToken: "dpop-token", dpopBound: true, dpopKeyRef });
+
+    const token = await NO_DEFAULT_IDAAS_CLIENT.getAccessToken({
+      audience: TEST_AUDIENCE,
+      dpop: { alg: "ES256" },
+    });
+
+    expect(token).toBe("dpop-token");
+  });
+
+  test("sends DPoP proof header on refresh-token exchange for DPoP-bound tokens", async () => {
+    const keyMaterial = await generateDpopKeyMaterial("ES256");
+    const dpopKeyRef = await persistDpopKeyMaterial({ alg: "ES256", ...keyMaterial });
+    storeToken({ ...TEST_ACCESS_TOKEN_OBJECT, expiresAt: 0, scope: "1", dpopBound: true, dpopKeyRef });
+
+    await NO_DEFAULT_IDAAS_CLIENT.getAccessToken({
+      scope: "1",
+      audience: TEST_AUDIENCE,
+      dpop: { alg: "ES256" },
+    });
+
+    const tokenEndpointCall = spyOnFetch.mock.calls.find((call) => call[0] === `${TEST_BASE_URI}/token`);
+    expect(tokenEndpointCall).toBeDefined();
+    const headers = tokenEndpointCall?.[1]?.headers as Record<string, string>;
+    expect(typeof headers.DPoP).toBe("string");
+    expect((headers.DPoP ?? "").length).toBeGreaterThan(10);
+  });
+
+  test("uses global DPoP config when selecting DPoP-bound tokens", async () => {
+    const keyMaterial = await generateDpopKeyMaterial("ES256");
+    const dpopKeyRef = await persistDpopKeyMaterial({ alg: "ES256", ...keyMaterial });
+    const globalDpopClient = new IdaasClient(
+      {
+        issuerUrl: TEST_ISSUER_URI,
+        clientId: TEST_CLIENT_ID,
+        storageType: "localstorage",
+      },
+      { dpop: { alg: "ES256" } },
+    );
+
+    // @ts-expect-error private method call
+    globalDpopClient.storageManager.saveAccessToken({ ...TEST_ACCESS_TOKEN_OBJECT, accessToken: "bearer-token" });
+    // @ts-expect-error private method call
+    globalDpopClient.storageManager.saveAccessToken({
+      ...TEST_ACCESS_TOKEN_OBJECT,
+      accessToken: "dpop-token",
+      dpopBound: true,
+      dpopKeyRef,
+    });
+
+    const token = await globalDpopClient.getAccessToken({ audience: TEST_AUDIENCE });
+
+    expect(token).toBe("dpop-token");
+  });
+
+  test("uses persisted DPoP key algorithm for DPoP-bound refresh even when configured alg differs", async () => {
+    const keyMaterial = await generateDpopKeyMaterial("PS256");
+    const dpopKeyRef = await persistDpopKeyMaterial({ alg: "PS256", ...keyMaterial });
+    storeToken({
+      ...TEST_ACCESS_TOKEN_OBJECT,
+      expiresAt: 0,
+      scope: "1",
+      dpopBound: true,
+      dpopKeyRef,
+    });
+
+    await NO_DEFAULT_IDAAS_CLIENT.getAccessToken({
+      scope: "1",
+      audience: TEST_AUDIENCE,
+      dpop: { alg: "ES256" },
+    });
+
+    const tokenEndpointCall = spyOnFetch.mock.calls.find((call) => call[0] === `${TEST_BASE_URI}/token`);
+    const headers = tokenEndpointCall?.[1]?.headers as Record<string, string>;
+
+    expect(headers.DPoP).toBeDefined();
+    expect(decodeProtectedHeader(headers.DPoP as string).alg).toBe("PS256");
   });
 
   describe("refresh token validity", () => {
@@ -211,6 +345,69 @@ describe("IdaasClient.getAccessToken", () => {
       // Verify access token was updated (comes from TEST_TOKEN_RESPONSE mock)
       expect(refreshedToken.accessToken).toBeTruthy();
       expect(refreshedToken.accessToken).toStrictEqual(TEST_ACCESS_TOKEN);
+    });
+
+    test("the refreshed token derives dpopBound from token_type in refresh response", async () => {
+      const keyMaterial = await generateDpopKeyMaterial("ES256");
+      const dpopKeyRef = await persistDpopKeyMaterial({ alg: "ES256", ...keyMaterial });
+      storeToken({ ...TEST_ACCESS_TOKEN_OBJECT, expiresAt: 0, dpopBound: true, dpopKeyRef });
+
+      await NO_DEFAULT_IDAAS_CLIENT.getAccessToken({ audience: TEST_AUDIENCE, dpop: { alg: "ES256" } });
+
+      const storedTokens = JSON.parse(localStorage.getItem(TEST_ACCESS_PAIR.key) as string);
+      const refreshedToken = storedTokens[0] as AccessToken;
+
+      expect(refreshedToken.dpopBound).toBeFalse();
+      expect(refreshedToken.dpopKeyRef).toBeUndefined();
+      expect(await retrievePersistedDpopKeyMaterial(dpopKeyRef)).toBeUndefined();
+    });
+
+    test("stores and returns refreshed token when stale DPoP key cleanup fails", async () => {
+      const keyMaterial = await generateDpopKeyMaterial("ES256");
+      const dpopKeyRef = await persistDpopKeyMaterial({ alg: "ES256", ...keyMaterial });
+      storeToken({ ...TEST_ACCESS_TOKEN_OBJECT, expiresAt: 0, dpopBound: true, dpopKeyRef });
+
+      let restoreIndexedDb: (() => void) | undefined;
+
+      // @ts-expect-error not full type
+      spyOnFetch.mockImplementation(async (url: string) => {
+        if (url === `${TEST_BASE_URI}/token`) {
+          return Promise.resolve({
+            json: () => {
+              restoreIndexedDb = blockIndexedDb();
+              return Promise.resolve({ ...TEST_TOKEN_RESPONSE, token_type: "Bearer" });
+            },
+            headers: {
+              get: () => null,
+            },
+          } as unknown as Response);
+        }
+
+        return mockFetch(url);
+      });
+
+      try {
+        const token = await NO_DEFAULT_IDAAS_CLIENT.getAccessToken({ audience: TEST_AUDIENCE, dpop: { alg: "ES256" } });
+        const storedTokens = JSON.parse(localStorage.getItem(TEST_ACCESS_PAIR.key) as string);
+        const refreshedToken = storedTokens[0] as AccessToken;
+
+        expect(token).toStrictEqual(TEST_ACCESS_TOKEN);
+        expect(refreshedToken.accessToken).toStrictEqual(TEST_ACCESS_TOKEN);
+        expect(refreshedToken.dpopBound).toBeFalse();
+        expect(refreshedToken.dpopKeyRef).toBeUndefined();
+      } finally {
+        restoreIndexedDb?.();
+      }
+    });
+
+    test("does not refresh a Bearer token when DPoP is enabled", async () => {
+      storeToken({ ...TEST_ACCESS_TOKEN_OBJECT, expiresAt: 0, dpopBound: false, dpopKeyRef: undefined });
+
+      await expect(
+        NO_DEFAULT_IDAAS_CLIENT.getAccessToken({ audience: TEST_AUDIENCE, dpop: { alg: "ES256" } }),
+      ).rejects.toThrow("Requested token not found");
+
+      expect(spyOnFetch.mock.calls.some((call) => call[0] === `${TEST_BASE_URI}/token`)).toBeFalse();
     });
   });
 

--- a/test/unit/IdaasClient/getDpopHeaders.test.ts
+++ b/test/unit/IdaasClient/getDpopHeaders.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { decodeProtectedHeader, importJWK, jwtVerify } from "jose";
+import { generateDpopKeyMaterial } from "../../../src/utils/dpop";
+import { persistDpopKeyMaterial } from "../../../src/utils/dpopKeyStore";
+import { NO_DEFAULT_IDAAS_CLIENT, TEST_ACCESS_TOKEN, TEST_ACCESS_TOKEN_OBJECT } from "../constants";
+
+const storeToken = (token: typeof TEST_ACCESS_TOKEN_OBJECT) => {
+  // @ts-expect-error private method call
+  NO_DEFAULT_IDAAS_CLIENT.storageManager.saveAccessToken(token);
+};
+
+describe("IdaasClient.getDpopHeaders", () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  test("throws when the selected token is not DPoP-bound", async () => {
+    storeToken(TEST_ACCESS_TOKEN_OBJECT);
+
+    await expect(
+      NO_DEFAULT_IDAAS_CLIENT.getDpopHeaders({
+        method: "GET",
+        uri: "https://api.example.com/accounts",
+        accessToken: TEST_ACCESS_TOKEN,
+      }),
+    ).rejects.toThrow("Selected access token is not DPoP-bound.");
+  });
+
+  test("returns DPoP Authorization and proof headers for a DPoP-bound token", async () => {
+    const keyMaterial = await generateDpopKeyMaterial("PS256");
+    const dpopKeyRef = await persistDpopKeyMaterial({ alg: "PS256", ...keyMaterial });
+
+    storeToken({
+      ...TEST_ACCESS_TOKEN_OBJECT,
+      accessToken: TEST_ACCESS_TOKEN,
+      dpopBound: true,
+      dpopKeyRef,
+    });
+
+    const headers = await NO_DEFAULT_IDAAS_CLIENT.getDpopHeaders({
+      method: "get",
+      uri: "https://api.example.com/accounts?include=balances#summary",
+      accessToken: TEST_ACCESS_TOKEN,
+    });
+
+    expect(headers.Authorization).toBe(`DPoP ${TEST_ACCESS_TOKEN}`);
+    expect(headers.DPoP).toBeDefined();
+
+    const protectedHeader = decodeProtectedHeader(headers.DPoP as string);
+    expect(protectedHeader.alg).toBe("PS256");
+    expect(protectedHeader.typ).toBe("dpop+jwt");
+    expect(protectedHeader.jwk).toBeDefined();
+
+    if (!protectedHeader.jwk) {
+      throw new Error("Expected DPoP proof to include a public JWK");
+    }
+
+    const verificationKey = await importJWK(protectedHeader.jwk, protectedHeader.alg);
+    const { payload } = await jwtVerify(headers.DPoP as string, verificationKey);
+
+    expect(payload.htm).toBe("GET");
+    expect(payload.htu).toBe("https://api.example.com/accounts");
+    expect(typeof payload.jti).toBe("string");
+    expect(typeof payload.ath).toBe("string");
+  });
+
+  test("rejects non-http protected resource URIs", async () => {
+    storeToken(TEST_ACCESS_TOKEN_OBJECT);
+
+    await expect(
+      NO_DEFAULT_IDAAS_CLIENT.getDpopHeaders({
+        method: "GET",
+        uri: "file:///tmp/accounts",
+        accessToken: TEST_ACCESS_TOKEN,
+      }),
+    ).rejects.toThrow("Protected resource URI must use http or https.");
+  });
+
+  test("rejects invalid protected resource URIs with SDK error", async () => {
+    storeToken(TEST_ACCESS_TOKEN_OBJECT);
+
+    await expect(
+      NO_DEFAULT_IDAAS_CLIENT.getDpopHeaders({
+        method: "GET",
+        uri: "/accounts",
+        accessToken: TEST_ACCESS_TOKEN,
+      }),
+    ).rejects.toThrow("Protected resource URI must be a valid absolute URL.");
+  });
+});

--- a/test/unit/IdaasClient/getUserInfo.test.ts
+++ b/test/unit/IdaasClient/getUserInfo.test.ts
@@ -1,5 +1,17 @@
 import { afterAll, afterEach, describe, expect, jest, spyOn, test } from "bun:test";
-import { NO_DEFAULT_IDAAS_CLIENT, TEST_ACCESS_TOKEN, TEST_BASE_URI, TEST_ID_PAIR, TEST_SUB_CLAIM } from "../constants";
+import { decodeProtectedHeader } from "jose";
+import { generateDpopKeyMaterial } from "../../../src/utils/dpop";
+import { persistDpopKeyMaterial } from "../../../src/utils/dpopKeyStore";
+import {
+  NO_DEFAULT_IDAAS_CLIENT,
+  TEST_ACCESS_TOKEN,
+  TEST_ACCESS_TOKEN_OBJECT,
+  TEST_BASE_URI,
+  TEST_DIFFERENT_ACCESS_TOKEN,
+  TEST_DIFFERENT_SCOPE,
+  TEST_ID_PAIR,
+  TEST_SUB_CLAIM,
+} from "../constants";
 import { mockFetch } from "../helpers";
 
 describe("IdaasClient.getUserInfo", () => {
@@ -48,5 +60,79 @@ describe("IdaasClient.getUserInfo", () => {
     // Test outcome: should return user info object
     expect(result).toBeDefined();
     expect(result?.sub).toStrictEqual(TEST_SUB_CLAIM);
+  });
+
+  test("uses persisted DPoP key algorithm for DPoP-bound UserInfo even when configured alg differs", async () => {
+    const keyMaterial = await generateDpopKeyMaterial("PS256");
+    const dpopKeyRef = await persistDpopKeyMaterial({ alg: "PS256", ...keyMaterial });
+
+    localStorage.setItem(TEST_ID_PAIR.key, JSON.stringify(TEST_ID_PAIR.data));
+    // @ts-expect-error private method call
+    NO_DEFAULT_IDAAS_CLIENT.storageManager.saveAccessToken({
+      ...TEST_ACCESS_TOKEN_OBJECT,
+      accessToken: TEST_ACCESS_TOKEN,
+      dpopBound: true,
+      dpopKeyRef,
+    });
+
+    await NO_DEFAULT_IDAAS_CLIENT.getUserInfo(TEST_ACCESS_TOKEN, { dpop: { alg: "ES256" } });
+
+    const userInfoRequest = spyOnFetch.mock.calls.find((request) => request[0] === `${TEST_BASE_URI}/userinfo`);
+    const headers = userInfoRequest?.[1]?.headers as Record<string, string>;
+
+    expect(headers.DPoP).toBeDefined();
+    expect(decodeProtectedHeader(headers.DPoP as string).alg).toBe("PS256");
+  });
+
+  test("uses persisted DPoP key reference for DPoP-bound UserInfo without tokenOptions.dpop", async () => {
+    const keyMaterial = await generateDpopKeyMaterial("PS256");
+    const dpopKeyRef = await persistDpopKeyMaterial({ alg: "PS256", ...keyMaterial });
+
+    localStorage.setItem(TEST_ID_PAIR.key, JSON.stringify(TEST_ID_PAIR.data));
+    // @ts-expect-error private method call
+    NO_DEFAULT_IDAAS_CLIENT.storageManager.saveAccessToken({
+      ...TEST_ACCESS_TOKEN_OBJECT,
+      accessToken: TEST_ACCESS_TOKEN,
+      dpopBound: true,
+      dpopKeyRef,
+    });
+
+    await NO_DEFAULT_IDAAS_CLIENT.getUserInfo(TEST_ACCESS_TOKEN);
+
+    const userInfoRequest = spyOnFetch.mock.calls.find((request) => request[0] === `${TEST_BASE_URI}/userinfo`);
+    const headers = userInfoRequest?.[1]?.headers as Record<string, string>;
+
+    expect(headers.DPoP).toBeDefined();
+    expect(decodeProtectedHeader(headers.DPoP as string).alg).toBe("PS256");
+  });
+
+  test("passes tokenOptions through when acquiring a UserInfo access token", async () => {
+    const keyMaterial = await generateDpopKeyMaterial("ES256");
+    const dpopKeyRef = await persistDpopKeyMaterial({ alg: "ES256", ...keyMaterial });
+
+    localStorage.setItem(TEST_ID_PAIR.key, JSON.stringify(TEST_ID_PAIR.data));
+    // @ts-expect-error private method call
+    NO_DEFAULT_IDAAS_CLIENT.storageManager.saveAccessToken({
+      ...TEST_ACCESS_TOKEN_OBJECT,
+      accessToken: TEST_ACCESS_TOKEN,
+      audience: undefined,
+    });
+    // @ts-expect-error private method call
+    NO_DEFAULT_IDAAS_CLIENT.storageManager.saveAccessToken({
+      ...TEST_ACCESS_TOKEN_OBJECT,
+      accessToken: TEST_DIFFERENT_ACCESS_TOKEN,
+      audience: undefined,
+      scope: TEST_DIFFERENT_SCOPE,
+      dpopBound: true,
+      dpopKeyRef,
+    });
+
+    await NO_DEFAULT_IDAAS_CLIENT.getUserInfo(undefined, { scope: TEST_DIFFERENT_SCOPE, dpop: { alg: "ES256" } });
+
+    const userInfoRequest = spyOnFetch.mock.calls.find((request) => request[0] === `${TEST_BASE_URI}/userinfo`);
+    const headers = userInfoRequest?.[1]?.headers as Record<string, string>;
+
+    expect(headers.Authorization).toBe(`DPoP ${TEST_DIFFERENT_ACCESS_TOKEN}`);
+    expect(headers.DPoP).toBeDefined();
   });
 });

--- a/test/unit/IdaasClient/handleRedirect.test.ts
+++ b/test/unit/IdaasClient/handleRedirect.test.ts
@@ -1,4 +1,7 @@
 import { afterAll, afterEach, beforeEach, describe, expect, jest, spyOn, test } from "bun:test";
+import type { AccessToken } from "../../../src/storage/StorageManager";
+import { generateDpopKeyMaterial } from "../../../src/utils/dpop";
+import { persistDpopKeyMaterial, retrievePersistedDpopKeyMaterial } from "../../../src/utils/dpopKeyStore";
 import * as jwt from "../../../src/utils/jwt";
 import {
   NO_DEFAULT_IDAAS_CLIENT,
@@ -6,7 +9,6 @@ import {
   TEST_ACCESS_TOKEN_KEY,
   TEST_ACR_CLAIM,
   TEST_BASE_URI,
-  TEST_CLIENT_ID,
   TEST_CODE,
   TEST_ID_TOKEN_KEY,
   TEST_ID_TOKEN_OBJECT,
@@ -117,7 +119,16 @@ describe("IdaasClient.handleRedirect", () => {
 
       await NO_DEFAULT_IDAAS_CLIENT.oidc.handleRedirect();
 
-      expect(localStorage.getItem(`entrust.tokenParams.${TEST_CLIENT_ID}`)).toBeNull();
+      expect(localStorage.getItem(TEST_TOKEN_PAIR.key)).toBeNull();
+    });
+
+    test("removes tokenParams from storage when redirect handling fails", async () => {
+      storeData({ clientParams: true, tokenParams: true });
+      window.location.href = `${TEST_BASE_URI}?code=${TEST_CODE}&state=different_state`;
+
+      await expect(NO_DEFAULT_IDAAS_CLIENT.oidc.handleRedirect()).rejects.toThrowError();
+
+      expect(localStorage.getItem(TEST_TOKEN_PAIR.key)).toBeNull();
     });
 
     test("stores the ID token", async () => {
@@ -209,6 +220,31 @@ describe("IdaasClient.handleRedirect", () => {
       expect(spyOnValidateIdToken).not.toHaveBeenCalled();
       expect(localStorage.getItem(TEST_ID_TOKEN_KEY)).not.toBeNull();
       expect(localStorage.getItem(TEST_ACCESS_TOKEN_KEY)).not.toBeNull();
+    });
+
+    test("does not store dpopKeyRef and cleans persisted key when redirect token response is Bearer", async () => {
+      const keyMaterial = await generateDpopKeyMaterial("ES256");
+      const dpopKeyRef = await persistDpopKeyMaterial({ alg: "ES256", ...keyMaterial });
+
+      localStorage.setItem(
+        TEST_TOKEN_PAIR.key,
+        JSON.stringify({
+          ...TEST_TOKEN_PARAMS,
+          dpop: { alg: "ES256", includeJkt: true },
+          dpopKeyRef,
+          requireIdToken: true,
+        }),
+      );
+      storeData({ clientParams: true });
+      window.location.href = loginSuccessUrl;
+
+      await NO_DEFAULT_IDAAS_CLIENT.oidc.handleRedirect();
+
+      const storedTokens = JSON.parse(localStorage.getItem(TEST_ACCESS_TOKEN_KEY) as string) as AccessToken[];
+
+      expect(storedTokens[0]?.dpopBound).toBeFalse();
+      expect(storedTokens[0]?.dpopKeyRef).toBeUndefined();
+      expect(await retrievePersistedDpopKeyMaterial(dpopKeyRef)).toBeUndefined();
     });
   });
 });

--- a/test/unit/IdaasClient/login.test.ts
+++ b/test/unit/IdaasClient/login.test.ts
@@ -1,5 +1,7 @@
 import { afterAll, afterEach, describe, expect, jest, spyOn, test } from "bun:test";
 import { IdaasClient } from "../../../src";
+import { generateDpopKeyMaterial } from "../../../src/utils/dpop";
+import { persistDpopKeyMaterial, retrievePersistedDpopKeyMaterial } from "../../../src/utils/dpopKeyStore";
 import { formatUrl } from "../../../src/utils/format";
 import * as urlUtils from "../../../src/utils/url";
 import {
@@ -233,6 +235,68 @@ describe("IdaasClient.oidc.login", () => {
 
       expect(acrArr).toContain(TEST_ACR_CLAIM);
       expect(acrArr).toContain(thisTestDifferentAcr);
+    });
+
+    test("auth url contains dpop_jkt when DPoP includeJkt is enabled", async () => {
+      await NO_DEFAULT_IDAAS_CLIENT.oidc.login({}, { dpop: { alg: "ES256", includeJkt: true } });
+
+      const { url: authUrl } = (await spyOnGenerateAuthorizationUrl.mock.results[0]?.value) as { url: string };
+      const { dpop_jkt: dpopJkt } = getUrlParams(authUrl);
+
+      expect(dpopJkt).toBeTruthy();
+    });
+
+    test("token params persist DPoP key reference when includeJkt is enabled", async () => {
+      await NO_DEFAULT_IDAAS_CLIENT.oidc.login({}, { dpop: { includeJkt: true, alg: "ES256" } });
+
+      const tokenParamsRaw = localStorage.getItem(TEST_TOKEN_PAIR.key);
+      expect(tokenParamsRaw).toBeTruthy();
+
+      const tokenParams = JSON.parse(tokenParamsRaw as string) as {
+        dpopKeyRef?: string;
+        dpopKeyMaterial?: unknown;
+      };
+
+      expect(tokenParams.dpopKeyRef).toBeTruthy();
+      expect(tokenParams.dpopKeyMaterial).toBeUndefined();
+      expect((tokenParamsRaw as string).includes("privateJwk")).toBeFalse();
+    });
+
+    test("cleans abandoned redirect DPoP key before saving new token params", async () => {
+      const keyMaterial = await generateDpopKeyMaterial("ES256");
+      const abandonedDpopKeyRef = await persistDpopKeyMaterial({ alg: "ES256", ...keyMaterial });
+      localStorage.setItem(
+        TEST_TOKEN_PAIR.key,
+        JSON.stringify({
+          ...TEST_TOKEN_PAIR.data,
+          dpop: { alg: "ES256", includeJkt: true },
+          dpopKeyRef: abandonedDpopKeyRef,
+        }),
+      );
+
+      await NO_DEFAULT_IDAAS_CLIENT.oidc.login({}, { dpop: { includeJkt: true, alg: "ES256" } });
+
+      const tokenParamsRaw = localStorage.getItem(TEST_TOKEN_PAIR.key);
+      expect(tokenParamsRaw).toBeTruthy();
+
+      const tokenParams = JSON.parse(tokenParamsRaw as string) as { dpopKeyRef?: string };
+      expect(tokenParams.dpopKeyRef).toBeTruthy();
+      expect(tokenParams.dpopKeyRef).not.toBe(abandonedDpopKeyRef);
+      expect(await retrievePersistedDpopKeyMaterial(abandonedDpopKeyRef)).toBeUndefined();
+      expect(await retrievePersistedDpopKeyMaterial(tokenParams.dpopKeyRef as string)).toBeDefined();
+    });
+
+    test("token params do not persist DPoP key reference when includeJkt is disabled", async () => {
+      await NO_DEFAULT_IDAAS_CLIENT.oidc.login({}, { dpop: { includeJkt: false, alg: "ES256" } });
+
+      const tokenParamsRaw = localStorage.getItem(TEST_TOKEN_PAIR.key);
+      expect(tokenParamsRaw).toBeTruthy();
+
+      const tokenParams = JSON.parse(tokenParamsRaw as string) as {
+        dpopKeyRef?: unknown;
+      };
+
+      expect(tokenParams.dpopKeyRef).toBeUndefined();
     });
 
     test("auth url does not contain claims request if acrValues is not passed", async () => {

--- a/test/unit/IdaasClient/logout.test.ts
+++ b/test/unit/IdaasClient/logout.test.ts
@@ -1,6 +1,12 @@
 import { afterAll, afterEach, describe, expect, jest, spyOn, test } from "bun:test";
-import { NO_DEFAULT_IDAAS_CLIENT, TEST_BASE_URI, TEST_CLIENT_ID } from "../constants";
-import { getUrlParams, mockFetch, storeData } from "../helpers";
+import {
+  NO_DEFAULT_IDAAS_CLIENT,
+  TEST_ACCESS_PAIR,
+  TEST_BASE_URI,
+  TEST_CLIENT_ID,
+  TEST_TOKEN_PAIR,
+} from "../constants";
+import { blockIndexedDb, getUrlParams, mockFetch, storeData } from "../helpers";
 
 describe("IdaasClient.oidc.logout", () => {
   // @ts-expect-error not full type
@@ -54,5 +60,50 @@ describe("IdaasClient.oidc.logout", () => {
     const { client_id, post_logout_redirect_uri } = getUrlParams(window.location.href);
     expect(client_id).toStrictEqual(TEST_CLIENT_ID);
     expect(post_logout_redirect_uri).toStrictEqual(TEST_BASE_URI);
+  });
+
+  test("clears stored data and redirects when DPoP cleanup fails", async () => {
+    storeData({ idToken: true, tokenParams: true, clientParams: true, accessToken: true });
+    localStorage.setItem(
+      TEST_ACCESS_PAIR.key,
+      JSON.stringify([{ ...TEST_ACCESS_PAIR.data[0], dpopKeyRef: "shared-dpop-key-ref" }]),
+    );
+    localStorage.setItem(
+      TEST_TOKEN_PAIR.key,
+      JSON.stringify({ ...TEST_TOKEN_PAIR.data, dpopKeyRef: "shared-dpop-key-ref" }),
+    );
+
+    const restoreIndexedDb = blockIndexedDb();
+
+    try {
+      await NO_DEFAULT_IDAAS_CLIENT.oidc.logout();
+
+      expect(localStorage.length).toBe(0);
+      expect(window.location.href).toContain("/endsession");
+    } finally {
+      restoreIndexedDb();
+    }
+  });
+
+  test("RBA logout clears stored data when DPoP cleanup fails", async () => {
+    storeData({ idToken: true, tokenParams: true, clientParams: true, accessToken: true });
+    localStorage.setItem(
+      TEST_ACCESS_PAIR.key,
+      JSON.stringify([{ ...TEST_ACCESS_PAIR.data[0], dpopKeyRef: "shared-dpop-key-ref" }]),
+    );
+    localStorage.setItem(
+      TEST_TOKEN_PAIR.key,
+      JSON.stringify({ ...TEST_TOKEN_PAIR.data, dpopKeyRef: "shared-dpop-key-ref" }),
+    );
+
+    const restoreIndexedDb = blockIndexedDb();
+
+    try {
+      await NO_DEFAULT_IDAAS_CLIENT.rba.logout();
+
+      expect(localStorage.length).toBe(0);
+    } finally {
+      restoreIndexedDb();
+    }
   });
 });

--- a/test/unit/IdaasClient/rbaCompletion.test.ts
+++ b/test/unit/IdaasClient/rbaCompletion.test.ts
@@ -3,7 +3,7 @@ import * as api from "../../../src/api";
 import { IdaasClient } from "../../../src/IdaasClient";
 import * as jwt from "../../../src/utils/jwt";
 import * as urlUtils from "../../../src/utils/url";
-import { TEST_CLIENT_ID, TEST_ISSUER_URI, TEST_OIDC_CONFIG } from "../constants";
+import { TEST_ACCESS_TOKEN_KEY, TEST_CLIENT_ID, TEST_ISSUER_URI, TEST_OIDC_CONFIG } from "../constants";
 
 describe("IdaasClient.rba completion", () => {
   // @ts-expect-error non full type
@@ -129,5 +129,73 @@ describe("IdaasClient.rba completion", () => {
 
     expect(spyOnRequestToken).toHaveBeenCalledTimes(1);
     expect(spyOnValidateIdToken).not.toHaveBeenCalled();
+  });
+
+  test("persists dpopKeyRef for DPoP-bound RBA tokens", async () => {
+    const client = new IdaasClient({
+      issuerUrl: TEST_ISSUER_URI,
+      clientId: TEST_CLIENT_ID,
+      storageType: "localstorage",
+    });
+
+    spyOnRequestToken.mockResolvedValueOnce({
+      access_token: "dpop-access-token",
+      id_token: "id-token",
+      token_type: "DPoP",
+      expires_in: "300",
+    });
+
+    await client.rba.requestChallenge(
+      {
+        userId: "user@example.com",
+        strict: true,
+        preferredAuthenticationMethod: "PASSWORD",
+      },
+      {
+        dpop: { alg: "ES256", includeJkt: true },
+      },
+    );
+
+    await client.rba.submitChallenge({ response: "password" });
+
+    const storedTokens = JSON.parse(localStorage.getItem(TEST_ACCESS_TOKEN_KEY) ?? "[]") as Array<{
+      accessToken: string;
+      dpopBound?: boolean;
+      dpopKeyRef?: string;
+    }>;
+
+    expect(storedTokens).toHaveLength(1);
+    expect(storedTokens[0]).toMatchObject({
+      accessToken: "dpop-access-token",
+      dpopBound: true,
+    });
+    expect(storedTokens[0]?.dpopKeyRef).toBeTruthy();
+  });
+
+  test("fails fast when RBA receives a DPoP-bound token without DPoP configuration", async () => {
+    const client = new IdaasClient({
+      issuerUrl: TEST_ISSUER_URI,
+      clientId: TEST_CLIENT_ID,
+      storageType: "localstorage",
+    });
+
+    spyOnRequestToken.mockResolvedValueOnce({
+      access_token: "dpop-access-token",
+      id_token: "id-token",
+      token_type: "DPoP",
+      expires_in: "300",
+    });
+
+    await client.rba.requestChallenge({
+      userId: "user@example.com",
+      strict: true,
+      preferredAuthenticationMethod: "PASSWORD",
+    });
+
+    await expect(client.rba.submitChallenge({ response: "password" })).rejects.toThrow(
+      "DPoP-bound token response received without DPoP key material",
+    );
+
+    expect(localStorage.getItem(TEST_ACCESS_TOKEN_KEY)).toBeNull();
   });
 });

--- a/test/unit/IdaasContext.test.ts
+++ b/test/unit/IdaasContext.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { IdaasContext } from "../../src/IdaasContext";
+import { retrievePersistedDpopKeyMaterial } from "../../src/utils/dpopKeyStore";
+import { TEST_BASE_URI, TEST_CLIENT_ID } from "./constants";
+
+describe("IdaasContext", () => {
+  const createContext = () =>
+    new IdaasContext({
+      issuerUrl: TEST_BASE_URI,
+      clientId: TEST_CLIENT_ID,
+      tokenOptions: {
+        scope: "openid profile email",
+        acrValues: "",
+        useRefreshToken: false,
+        includeOpenidScope: true,
+      },
+    });
+
+  test("persists key material for the requested algorithm after another algorithm is used", async () => {
+    const context = createContext();
+
+    await context.getDpopJkt({ alg: "ES256", includeJkt: true });
+    await context.createDpopProof({
+      method: "POST",
+      uri: "https://example.com/token",
+      dpopOptions: { alg: "PS256" },
+    });
+
+    const dpopKeyRef = await context.persistCurrentDpopKeyMaterialForAlg("ES256");
+    const persistedKeyMaterial = await retrievePersistedDpopKeyMaterial(dpopKeyRef);
+
+    expect(persistedKeyMaterial?.alg).toBe("ES256");
+  });
+});

--- a/test/unit/api.test.ts
+++ b/test/unit/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, spyOn } from "bun:test";
-import { fetchOpenidConfiguration } from "../../src/api";
+import { fetchOpenidConfiguration, getUserInfo, requestToken } from "../../src/api";
 
 describe("api.ts", () => {
   describe("fetchOpenidConfiguration", () => {
@@ -38,6 +38,46 @@ describe("api.ts", () => {
 
       // Clean up
       mockFetch.mockRestore();
+    });
+  });
+
+  describe("requestToken", () => {
+    it("includes DPoP header when dpop proof is provided", async () => {
+      const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValueOnce({
+        json: async () => ({ access_token: "a", token_type: "DPoP", expires_in: "300" }),
+        headers: {
+          get: () => null,
+        },
+      } as unknown as Response);
+
+      await requestToken(
+        "https://example.com/token",
+        {
+          grant_type: "refresh_token",
+          client_id: "client",
+          refresh_token: "refresh",
+        },
+        "signed-dpop-proof",
+      );
+
+      const headers = fetchSpy.mock.calls[0]?.[1]?.headers as Record<string, string>;
+      expect(headers.DPoP).toBe("signed-dpop-proof");
+      fetchSpy.mockRestore();
+    });
+  });
+
+  describe("getUserInfo", () => {
+    it("uses DPoP auth scheme and header when proof is provided", async () => {
+      const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValueOnce({
+        text: async () => "{}",
+      } as unknown as Response);
+
+      await getUserInfo("https://example.com/userinfo", "access-token", "dpop-proof");
+
+      const headers = fetchSpy.mock.calls[0]?.[1]?.headers as Record<string, string>;
+      expect(headers.Authorization).toBe("DPoP access-token");
+      expect(headers.DPoP).toBe("dpop-proof");
+      fetchSpy.mockRestore();
     });
   });
 });

--- a/test/unit/helpers.ts
+++ b/test/unit/helpers.ts
@@ -60,6 +60,9 @@ export const mockFetch = async (url: string) => {
     case `${TEST_BASE_URI}/token`: {
       return Promise.resolve({
         json: () => Promise.resolve(TEST_TOKEN_RESPONSE),
+        headers: {
+          get: () => null,
+        },
       });
     }
     case `${TEST_BASE_URI}/issuer/.well-known/openid-configuration`: {
@@ -108,4 +111,29 @@ export const getUrlParams = (href: string) => {
   });
 
   return paramData;
+};
+
+export const blockIndexedDb = (): (() => void) => {
+  const originalIndexedDb = globalThis.indexedDB;
+
+  Object.defineProperty(globalThis, "indexedDB", {
+    configurable: true,
+    value: {
+      open: () => {
+        throw new Error("IndexedDB blocked");
+      },
+    },
+  });
+
+  return () => {
+    if (originalIndexedDb) {
+      Object.defineProperty(globalThis, "indexedDB", {
+        configurable: true,
+        value: originalIndexedDb,
+      });
+      return;
+    }
+
+    Reflect.deleteProperty(globalThis, "indexedDB");
+  };
 };

--- a/test/unit/storage/StorageManager.test.ts
+++ b/test/unit/storage/StorageManager.test.ts
@@ -59,6 +59,43 @@ describe("StorageManager", () => {
       expect(tokens).toEqual([token1]);
     });
 
+    test("returns orphaned dpopKeyRef from the stored token when removing by access token", () => {
+      const token = { ...getAccessToken(), dpopKeyRef: "stored-dpop-key-ref" };
+
+      storageManager.saveAccessToken(token);
+
+      const orphanedDpopKeyRef = storageManager.removeAccessToken({ ...token, dpopKeyRef: undefined });
+
+      expect(orphanedDpopKeyRef).toBe("stored-dpop-key-ref");
+    });
+
+    test("removes adjacent expired tokens and returns their orphaned dpopKeyRefs", () => {
+      const expiredToken1 = {
+        ...getAccessToken(),
+        accessToken: "expired-token-1",
+        expiresAt: 0,
+        refreshToken: undefined,
+        dpopKeyRef: "expired-dpop-key-ref-1",
+      };
+      const expiredToken2 = {
+        ...getAccessToken(),
+        accessToken: "expired-token-2",
+        expiresAt: 0,
+        refreshToken: undefined,
+        dpopKeyRef: "expired-dpop-key-ref-2",
+      };
+      const validToken = getAccessToken();
+
+      storageManager.saveAccessToken(expiredToken1);
+      storageManager.saveAccessToken(expiredToken2);
+      storageManager.saveAccessToken(validToken);
+
+      const orphanedDpopKeyRefs = storageManager.removeExpiredTokens();
+
+      expect(storageManager.getAccessTokens()).toStrictEqual([validToken]);
+      expect(orphanedDpopKeyRefs).toStrictEqual(["expired-dpop-key-ref-1", "expired-dpop-key-ref-2"]);
+    });
+
     test("stores multiple tokens with different scopes, same audience", () => {
       const token1 = getAccessToken({ scope: "1" });
       const token2 = getAccessToken({ scope: "2" });
@@ -138,6 +175,7 @@ describe("StorageManager", () => {
     storageManager.saveAccessToken(getAccessToken());
     storageManager.saveClientParams(getClientParams());
     storageManager.saveIdToken(getIdToken());
+    storageManager.saveIdaasSessionToken({ token: "testing-session-token" });
     storageManager.saveTokenParams(getTokenParams());
 
     storageManager.remove();
@@ -145,6 +183,7 @@ describe("StorageManager", () => {
     expect(storageManager.getAccessTokens().length).toBe(0);
     expect(storageManager.getClientParams()).toBeUndefined();
     expect(storageManager.getIdToken()).toBeUndefined();
+    expect(storageManager.getIdaasSessionToken()).toBeUndefined();
     expect(storageManager.getTokenParams()).toBeUndefined();
 
     expect(localStorage.length).toBe(0);

--- a/test/unit/utils/dpop.test.ts
+++ b/test/unit/utils/dpop.test.ts
@@ -1,0 +1,379 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import { decodeJwt, decodeProtectedHeader, type JWK } from "jose";
+import { type DPoPAlg, generateDpopKeyMaterial, generateDpopProofJwt } from "../../../src/utils/dpop";
+
+describe("DPoP Key Material and Proof Generation", () => {
+  const supportedAlgs: DPoPAlg[] = ["ES256", "PS256", "RS256"];
+
+  describe("generateDpopKeyMaterial", () => {
+    supportedAlgs.forEach((alg) => {
+      describe(`Algorithm: ${alg}`, () => {
+        let keyMaterial: Awaited<ReturnType<typeof generateDpopKeyMaterial>>;
+
+        beforeEach(async () => {
+          keyMaterial = await generateDpopKeyMaterial(alg);
+        });
+
+        it("generates a valid DPoP key material object", async () => {
+          expect(keyMaterial).toBeDefined();
+          expect(keyMaterial.privateKey).toBeDefined();
+          expect(keyMaterial.publicJwk).toBeDefined();
+          expect(keyMaterial.jkt).toBeDefined();
+        });
+
+        it("returns a CryptoKey for privateKey", () => {
+          expect(keyMaterial.privateKey).toBeInstanceOf(CryptoKey);
+          expect(keyMaterial.privateKey.type).toBe("private");
+          expect(keyMaterial.privateKey.extractable).toBe(false);
+        });
+
+        it("returns a valid JWK for publicJwk", () => {
+          const jwk = keyMaterial.publicJwk as JWK;
+          expect(jwk.kty).toBeDefined();
+          expect(jwk.crv || jwk.n).toBeDefined(); // EC has crv, RSA has n
+        });
+
+        it("generates a base64url-encoded JWK thumbprint (jkt)", () => {
+          const jkt = keyMaterial.jkt;
+          // JWK thumbprints are base64url without padding
+          expect(jkt).toMatch(/^[A-Za-z0-9_-]+$/);
+          // Typical SHA-256 thumbprint is 43 characters in base64url
+          expect(jkt.length).toBeGreaterThan(0);
+        });
+
+        it("generates a different jkt for newly generated key material", async () => {
+          // Note: We can't directly test consistency since we can't re-import the same CryptoKey,
+          // but we can verify the jkt is valid
+          const jkt2 = await generateDpopKeyMaterial(alg);
+          expect(jkt2.jkt).not.toBe(keyMaterial.jkt); // Different keys have different jkts
+          expect(jkt2.jkt).toMatch(/^[A-Za-z0-9_-]+$/);
+        });
+
+        it("has correct algorithm settings for EC keys (ES256/ES384/ES512)", async () => {
+          if (!alg.startsWith("ES")) return;
+
+          const jwk = keyMaterial.publicJwk as JWK;
+          expect(jwk.kty).toBe("EC");
+          expect(jwk.crv).toBeDefined();
+
+          const expectedCurve = alg === "ES256" ? "P-256" : alg === "ES384" ? "P-384" : "P-521";
+          expect(jwk.crv).toBe(expectedCurve);
+          expect(jwk.x).toBeDefined();
+          expect(jwk.y).toBeDefined();
+        });
+
+        it("has correct algorithm settings for RSA keys (RS256/PS256)", async () => {
+          if (!alg.startsWith("R") && !alg.startsWith("P")) return;
+
+          const jwk = keyMaterial.publicJwk as JWK;
+          expect(jwk.kty).toBe("RSA");
+          expect(jwk.n).toBeDefined();
+          expect(jwk.e).toBeDefined();
+        });
+      });
+    });
+
+    it("generates unique key material on each call", async () => {
+      const material1 = await generateDpopKeyMaterial("ES256");
+      const material2 = await generateDpopKeyMaterial("ES256");
+
+      expect(material1.jkt).not.toBe(material2.jkt);
+    });
+  });
+
+  describe("generateDpopProofJwt", () => {
+    let keyMaterial: Awaited<ReturnType<typeof generateDpopKeyMaterial>>;
+
+    beforeEach(async () => {
+      keyMaterial = await generateDpopKeyMaterial("ES256");
+    });
+
+    it("generates a valid JWT string", async () => {
+      const proof = await generateDpopProofJwt({
+        alg: "ES256",
+        privateKey: keyMaterial.privateKey,
+        publicJwk: keyMaterial.publicJwk,
+        htm: "POST",
+        htu: "https://example.com/token",
+      });
+
+      expect(typeof proof).toBe("string");
+      expect(proof.split(".").length).toBe(3); // JWT has 3 parts
+    });
+
+    it("creates a JWT with correct protected header", async () => {
+      const proof = await generateDpopProofJwt({
+        alg: "ES256",
+        privateKey: keyMaterial.privateKey,
+        publicJwk: keyMaterial.publicJwk,
+        htm: "GET",
+        htu: "https://example.com/userinfo",
+      });
+
+      const header = decodeProtectedHeader(proof);
+      expect(header.alg).toBe("ES256");
+      expect(header.typ).toBe("dpop+jwt");
+      expect(header.jwk).toBeDefined();
+    });
+
+    it("includes required DPoP claims: htm, htu, iat, exp, jti", async () => {
+      const proof = await generateDpopProofJwt({
+        alg: "ES256",
+        privateKey: keyMaterial.privateKey,
+        publicJwk: keyMaterial.publicJwk,
+        htm: "POST",
+        htu: "https://example.com/token",
+      });
+
+      const claims = decodeJwt(proof);
+      expect(claims.htm).toBe("POST");
+      expect(claims.htu).toBe("https://example.com/token");
+      expect(claims.iat).toBeDefined();
+      expect(claims.exp).toBeDefined();
+      expect(claims.jti).toBeDefined();
+    });
+
+    it("normalizes htm to uppercase", async () => {
+      const proofLower = await generateDpopProofJwt({
+        alg: "ES256",
+        privateKey: keyMaterial.privateKey,
+        publicJwk: keyMaterial.publicJwk,
+        htm: "post",
+        htu: "https://example.com/token",
+      });
+
+      const claimsLower = decodeJwt(proofLower);
+      expect(claimsLower.htm).toBe("POST");
+
+      const proofUpper = await generateDpopProofJwt({
+        alg: "ES256",
+        privateKey: keyMaterial.privateKey,
+        publicJwk: keyMaterial.publicJwk,
+        htm: "POST",
+        htu: "https://example.com/token",
+      });
+
+      const claimsUpper = decodeJwt(proofUpper);
+      expect(claimsUpper.htm).toBe("POST");
+    });
+
+    it("sets exp to iat + 60 seconds", async () => {
+      const beforeProof = Math.floor(Date.now() / 1000);
+
+      const proof = await generateDpopProofJwt({
+        alg: "ES256",
+        privateKey: keyMaterial.privateKey,
+        publicJwk: keyMaterial.publicJwk,
+        htm: "POST",
+        htu: "https://example.com/token",
+      });
+
+      const afterProof = Math.floor(Date.now() / 1000);
+      const claims = decodeJwt(proof);
+
+      // iat should be between beforeProof and afterProof
+      expect((claims.iat as number) >= beforeProof).toBe(true);
+      expect((claims.iat as number) <= afterProof).toBe(true);
+
+      // exp should be iat + 60
+      expect(claims.exp).toBe((claims.iat as number) + 60);
+    });
+
+    it("includes ath claim when accessToken is provided", async () => {
+      const accessToken = "test_access_token_12345";
+
+      const proof = await generateDpopProofJwt({
+        alg: "ES256",
+        privateKey: keyMaterial.privateKey,
+        publicJwk: keyMaterial.publicJwk,
+        htm: "POST",
+        htu: "https://example.com/token",
+        accessToken,
+      });
+
+      const claims = decodeJwt(proof);
+      expect(claims.ath).toBeDefined();
+      expect(typeof claims.ath).toBe("string");
+      // ath is base64url encoded
+      expect(claims.ath as string).toMatch(/^[A-Za-z0-9_-]+$/);
+    });
+
+    it("does not include ath claim when accessToken is not provided", async () => {
+      const proof = await generateDpopProofJwt({
+        alg: "ES256",
+        privateKey: keyMaterial.privateKey,
+        publicJwk: keyMaterial.publicJwk,
+        htm: "POST",
+        htu: "https://example.com/token",
+      });
+
+      const claims = decodeJwt(proof);
+      expect(claims.ath).toBeUndefined();
+    });
+
+    it("generates unique jti for each proof (replay protection)", async () => {
+      const proof1 = await generateDpopProofJwt({
+        alg: "ES256",
+        privateKey: keyMaterial.privateKey,
+        publicJwk: keyMaterial.publicJwk,
+        htm: "POST",
+        htu: "https://example.com/token",
+      });
+
+      const proof2 = await generateDpopProofJwt({
+        alg: "ES256",
+        privateKey: keyMaterial.privateKey,
+        publicJwk: keyMaterial.publicJwk,
+        htm: "POST",
+        htu: "https://example.com/token",
+      });
+
+      const claims1 = decodeJwt(proof1);
+      const claims2 = decodeJwt(proof2);
+
+      expect(claims1.jti).not.toBe(claims2.jti);
+    });
+
+    it("normalizes htu by removing query and fragment", async () => {
+      const htu = "https://example.com:8080/api/v1/token?param=value#fragment";
+
+      const proof = await generateDpopProofJwt({
+        alg: "ES256",
+        privateKey: keyMaterial.privateKey,
+        publicJwk: keyMaterial.publicJwk,
+        htm: "POST",
+        htu,
+      });
+
+      const claims = decodeJwt(proof);
+      expect(claims.htu).toBe("https://example.com:8080/api/v1/token");
+    });
+
+    it("works with different algorithms", async () => {
+      const algsToTest: DPoPAlg[] = ["ES256", "PS256", "RS256"];
+
+      for (const alg of algsToTest) {
+        const material = await generateDpopKeyMaterial(alg);
+
+        const proof = await generateDpopProofJwt({
+          alg,
+          privateKey: material.privateKey,
+          publicJwk: material.publicJwk,
+          htm: "POST",
+          htu: "https://example.com/token",
+        });
+
+        expect(proof).toBeDefined();
+        expect(proof.split(".").length).toBe(3);
+
+        const header = decodeProtectedHeader(proof);
+        expect(header.alg).toBe(alg);
+      }
+    });
+
+    it("includes the correct public JWK in the protected header", async () => {
+      const proof = await generateDpopProofJwt({
+        alg: "ES256",
+        privateKey: keyMaterial.privateKey,
+        publicJwk: keyMaterial.publicJwk,
+        htm: "POST",
+        htu: "https://example.com/token",
+      });
+
+      const header = decodeProtectedHeader(proof);
+      expect(header.jwk).toEqual(keyMaterial.publicJwk);
+    });
+
+    it("produces cryptographically valid JWT (can be decoded without error)", async () => {
+      const proof = await generateDpopProofJwt({
+        alg: "ES256",
+        privateKey: keyMaterial.privateKey,
+        publicJwk: keyMaterial.publicJwk,
+        htm: "POST",
+        htu: "https://example.com/token",
+      });
+
+      // These should not throw
+      expect(() => decodeProtectedHeader(proof)).not.toThrow();
+      expect(() => decodeJwt(proof)).not.toThrow();
+    });
+
+    describe("ath (access token hash) generation", () => {
+      it("generates consistent ath for the same access token", async () => {
+        const accessToken = "my_access_token";
+
+        const proof1 = await generateDpopProofJwt({
+          alg: "ES256",
+          privateKey: keyMaterial.privateKey,
+          publicJwk: keyMaterial.publicJwk,
+          htm: "POST",
+          htu: "https://example.com/token",
+          accessToken,
+        });
+
+        const proof2 = await generateDpopProofJwt({
+          alg: "ES256",
+          privateKey: keyMaterial.privateKey,
+          publicJwk: keyMaterial.publicJwk,
+          htm: "POST",
+          htu: "https://example.com/token",
+          accessToken,
+        });
+
+        const claims1 = decodeJwt(proof1);
+        const claims2 = decodeJwt(proof2);
+
+        // Both should have ath
+        expect(claims1.ath).toBeDefined();
+        expect(claims2.ath).toBeDefined();
+
+        // ath values should be identical for the same token
+        expect(claims1.ath).toBe(claims2.ath);
+      });
+
+      it("generates different ath for different access tokens", async () => {
+        const proof1 = await generateDpopProofJwt({
+          alg: "ES256",
+          privateKey: keyMaterial.privateKey,
+          publicJwk: keyMaterial.publicJwk,
+          htm: "POST",
+          htu: "https://example.com/token",
+          accessToken: "token_one",
+        });
+
+        const proof2 = await generateDpopProofJwt({
+          alg: "ES256",
+          privateKey: keyMaterial.privateKey,
+          publicJwk: keyMaterial.publicJwk,
+          htm: "POST",
+          htu: "https://example.com/token",
+          accessToken: "token_two",
+        });
+
+        const claims1 = decodeJwt(proof1);
+        const claims2 = decodeJwt(proof2);
+
+        expect(claims1.ath).not.toBe(claims2.ath);
+      });
+
+      it("ath is base64url encoded without padding", async () => {
+        const proof = await generateDpopProofJwt({
+          alg: "ES256",
+          privateKey: keyMaterial.privateKey,
+          publicJwk: keyMaterial.publicJwk,
+          htm: "POST",
+          htu: "https://example.com/token",
+          accessToken: "test_token",
+        });
+
+        const claims = decodeJwt(proof);
+        const ath = claims.ath as string;
+
+        // Should be base64url
+        expect(ath).toMatch(/^[A-Za-z0-9_-]+$/);
+        // Should not have padding
+        expect(ath).not.toMatch(/=/);
+      });
+    });
+  });
+});

--- a/test/unit/utils/dpopKeyStore.test.ts
+++ b/test/unit/utils/dpopKeyStore.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { generateDpopKeyMaterial } from "../../../src/utils/dpop";
+import { persistDpopKeyMaterial } from "../../../src/utils/dpopKeyStore";
+import { blockIndexedDb } from "../helpers";
+
+describe("DPoP key store", () => {
+  let restoreIndexedDb: (() => void) | undefined;
+
+  afterEach(() => {
+    restoreIndexedDb?.();
+    restoreIndexedDb = undefined;
+  });
+
+  test("throws clear SDK error when IndexedDB open fails during persistence", async () => {
+    const keyMaterial = await generateDpopKeyMaterial("ES256");
+    restoreIndexedDb = blockIndexedDb();
+
+    await expect(persistDpopKeyMaterial({ alg: "ES256", ...keyMaterial })).rejects.toThrow(
+      "DPoP requires IndexedDB support to persist key material. Disable DPoP or use a browser with IndexedDB.",
+    );
+  });
+});


### PR DESCRIPTION
This PR introduces end-to-end DPoP support across the SDK by adding configurable DPoP token options, generating and managing DPoP key material/proof JWTs, optionally adding dpop_jkt to authorization requests, sending DPoP headers for token and UserInfo calls, and correctly persisting/handling DPoP-bound tokens across OIDC and RBA flows (including refresh and redirect continuity), with unit tests updated to verify the new request headers, URL parameters, key-material persistence behavior, and DPoP-specific token handling while keeping non-DPoP behavior unchanged by default.